### PR TITLE
feat(auth): add password recovery flow with forgot/reset password scr…

### DIFF
--- a/TheRecruitingCompass/TheRecruitingCompass/Core/Models/AuthError.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Core/Models/AuthError.swift
@@ -14,6 +14,9 @@ enum AuthError: LocalizedError {
   case passwordsDoNotMatch
   case invalidFamilyCode
   case termsNotAccepted
+  case invalidResetToken
+  case expiredResetToken
+  case resetEmailNotFound
   case unknown(Error)
 
   var errorDescription: String? {
@@ -47,6 +50,12 @@ enum AuthError: LocalizedError {
       return "Invalid family code format or code not found"
     case .termsNotAccepted:
       return "You must accept the terms and conditions"
+    case .invalidResetToken:
+      return "This password reset link is invalid."
+    case .expiredResetToken:
+      return "This password reset link has expired."
+    case .resetEmailNotFound:
+      return "No account found with this email address."
     case .unknown(let error):
       return error.localizedDescription
     }
@@ -76,6 +85,12 @@ enum AuthError: LocalizedError {
       return "Check the family code format or confirm it with the family administrator."
     case .termsNotAccepted:
       return "Please accept the terms and conditions to continue."
+    case .invalidResetToken:
+      return "Request a new password reset link."
+    case .expiredResetToken:
+      return "Request a new password reset link to continue."
+    case .resetEmailNotFound:
+      return "Check the email address or create a new account."
     case .unknown:
       return "Please try again or contact support."
     }

--- a/TheRecruitingCompass/TheRecruitingCompass/Core/Protocols/AuthManaging.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Core/Protocols/AuthManaging.swift
@@ -11,4 +11,6 @@ protocol AuthManaging: AnyObject {
   func logout() async throws
   func refreshSession() async throws -> User
   func resendVerificationEmail(email: String) async throws
+  func resetPasswordForEmail(email: String) async throws
+  func updatePassword(newPassword: String) async throws
 }

--- a/TheRecruitingCompass/TheRecruitingCompass/Core/Services/AuthManager.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Core/Services/AuthManager.swift
@@ -90,6 +90,26 @@ final class AuthManager: ObservableObject, AuthManaging {
     }
   }
 
+  func resetPasswordForEmail(email: String) async throws {
+    do {
+      try await SupabaseManager.shared.resetPasswordForEmail(email: email)
+      self.errorMessage = nil
+    } catch {
+      self.errorMessage = (error as? AuthError)?.errorDescription ?? error.localizedDescription
+      throw error
+    }
+  }
+
+  func updatePassword(newPassword: String) async throws {
+    do {
+      try await SupabaseManager.shared.updatePassword(newPassword: newPassword)
+      self.errorMessage = nil
+    } catch {
+      self.errorMessage = (error as? AuthError)?.errorDescription ?? error.localizedDescription
+      throw error
+    }
+  }
+
   func logout() async throws {
     do {
       try await SupabaseManager.shared.signOut()

--- a/TheRecruitingCompass/TheRecruitingCompass/Core/Services/SupabaseManager.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Core/Services/SupabaseManager.swift
@@ -96,6 +96,33 @@ class SupabaseManager {
     }
   }
 
+  func resetPasswordForEmail(email: String) async throws {
+    do {
+      try await client.auth.resetPasswordForEmail(email)
+    } catch {
+      let description = error.localizedDescription.lowercased()
+      if description.contains("not found") || description.contains("no user") {
+        throw AuthError.resetEmailNotFound
+      }
+      throw AuthError.serverError("Failed to send password reset email")
+    }
+  }
+
+  func updatePassword(newPassword: String) async throws {
+    do {
+      try await client.auth.update(user: UserAttributes(password: newPassword))
+    } catch {
+      let description = error.localizedDescription.lowercased()
+      if description.contains("invalid") || description.contains("token") {
+        throw AuthError.invalidResetToken
+      }
+      if description.contains("expired") {
+        throw AuthError.expiredResetToken
+      }
+      throw AuthError.serverError("Failed to update password")
+    }
+  }
+
   // MARK: - Private Helpers
 
   private func mapToUser(_ authUser: Supabase.User) -> User {

--- a/TheRecruitingCompass/TheRecruitingCompass/Core/Utilities/DeepLinkHandler.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Core/Utilities/DeepLinkHandler.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum DeepLinkRoute: Equatable {
+  case resetPassword(token: String)
+  case unknown
+}
+
+enum DeepLinkHandler {
+  static let scheme = "recruiting-compass"
+
+  static func parse(_ url: URL) -> DeepLinkRoute {
+    guard url.scheme == scheme else {
+      return .unknown
+    }
+
+    guard url.host == "reset-password" else {
+      return .unknown
+    }
+
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let token = components.queryItems?.first(where: { $0.name == "token" })?.value,
+          !token.isEmpty else {
+      return .unknown
+    }
+
+    return .resetPassword(token: token)
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Components/PasswordFormField.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Components/PasswordFormField.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct PasswordFormField: View {
+  let label: String
+  let placeholder: String
+  @Binding var text: String
+  @Binding var error: String?
+  @Binding var isPasswordVisible: Bool
+  let onBlur: () -> Void
+  @Environment(\.sizeCategory) var sizeCategory
+
+  private var iconWidth: CGFloat {
+    sizeCategory >= .extraLarge ? 22 : 20
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text(label)
+        .font(.footnote.weight(.semibold))
+        .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+        .accessibilityHidden(true)
+
+      HStack(spacing: 12) {
+        Image(systemName: "lock")
+          .foregroundColor(Color(red: 0.627, green: 0.655, blue: 0.686))
+          .frame(width: iconWidth)
+          .accessibilityHidden(true)
+
+        if isPasswordVisible {
+          TextField(placeholder, text: $text)
+            .accessibilityLabel(label)
+            .accessibilityHint(error ?? "")
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+            .onSubmit(onBlur)
+        } else {
+          SecureField(placeholder, text: $text)
+            .accessibilityLabel(label)
+            .accessibilityHint(error ?? "")
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+            .onSubmit(onBlur)
+        }
+
+        Button(action: { isPasswordVisible.toggle() }) {
+          Image(systemName: isPasswordVisible ? "eye.slash" : "eye")
+            .foregroundColor(Color(red: 0.627, green: 0.655, blue: 0.686))
+            .frame(width: iconWidth)
+        }
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Rectangle())
+        .accessibilityLabel(isPasswordVisible ? "Hide password" : "Show password")
+        .accessibilityHint("Double tap to \(isPasswordVisible ? "hide" : "show") password text")
+      }
+      .padding(12)
+      .background(Color.white)
+      .border(error != nil ? Color.red : Color(red: 0.82, green: 0.843, blue: 0.863), width: 1)
+      .cornerRadius(8)
+
+      if let error = error {
+        Text(error)
+          .font(.caption)
+          .foregroundColor(Color(red: 0.859, green: 0.149, blue: 0.149))
+          .accessibilityLabel("Error: \(error)")
+      }
+    }
+    .accessibilityElement(children: .combine)
+  }
+}
+
+#Preview {
+  @Previewable @State var text = ""
+  @Previewable @State var error: String? = nil
+  @Previewable @State var isVisible = false
+
+  PasswordFormField(
+    label: "New Password",
+    placeholder: "Enter your new password",
+    text: $text,
+    error: $error,
+    isPasswordVisible: $isVisible,
+    onBlur: {}
+  )
+  .padding()
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/ViewModels/ForgotPasswordViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/ViewModels/ForgotPasswordViewModel.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Combine
+
+@MainActor
+class ForgotPasswordViewModel: ObservableObject {
+  @Published var email = ""
+  @Published var isLoading = false
+  @Published var emailSent = false
+  @Published var submittedEmail = ""
+  @Published var errorMessage: String?
+  @Published var fieldErrors: [String: String] = [:]
+  @Published var canResendEmail = true
+  @Published var resendCooldownSeconds = 0
+
+  private let authManager: any AuthManaging
+  private var cooldownTimer: AnyCancellable?
+
+  var isFormValid: Bool {
+    !email.trimmingCharacters(in: .whitespaces).isEmpty && fieldErrors.isEmpty
+  }
+
+  var isButtonDisabled: Bool {
+    isLoading || !isFormValid
+  }
+
+  init(authManager: any AuthManaging = AuthManager.shared) {
+    self.authManager = authManager
+  }
+
+  func validateEmail() {
+    if let error = FormValidator.validateEmail(email) {
+      fieldErrors["email"] = error
+    } else {
+      fieldErrors["email"] = nil
+    }
+  }
+
+  func sendResetLink() async {
+    isLoading = true
+    errorMessage = nil
+    defer { isLoading = false }
+
+    validateEmail()
+    guard isFormValid else { return }
+
+    do {
+      try await authManager.resetPasswordForEmail(email: email)
+      submittedEmail = email
+      emailSent = true
+    } catch {
+      errorMessage = mapError(error)
+    }
+  }
+
+  func resendResetLink() async {
+    guard canResendEmail else { return }
+
+    isLoading = true
+    errorMessage = nil
+    defer { isLoading = false }
+
+    do {
+      try await authManager.resetPasswordForEmail(email: submittedEmail)
+      startResendCooldown()
+    } catch {
+      errorMessage = mapError(error)
+    }
+  }
+
+  func resetForm() {
+    emailSent = false
+    submittedEmail = ""
+    errorMessage = nil
+    fieldErrors = [:]
+  }
+
+  func dismissError() {
+    errorMessage = nil
+  }
+
+  private func startResendCooldown() {
+    canResendEmail = false
+    resendCooldownSeconds = 60
+
+    cooldownTimer = Timer.publish(every: 1, on: .main, in: .common)
+      .autoconnect()
+      .sink { [weak self] _ in
+        guard let self else { return }
+        self.resendCooldownSeconds -= 1
+        if self.resendCooldownSeconds <= 0 {
+          self.canResendEmail = true
+          self.cooldownTimer?.cancel()
+        }
+      }
+  }
+
+  private func mapError(_ error: Error) -> String {
+    if let authError = error as? AuthError {
+      return authError.errorDescription ?? "An error occurred"
+    }
+    return "An error occurred. Please try again."
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/ViewModels/ResetPasswordViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/ViewModels/ResetPasswordViewModel.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Combine
+
+enum ResetPasswordState: Equatable {
+  case form
+  case resetting
+  case success
+  case error(message: String)
+}
+
+@MainActor
+class ResetPasswordViewModel: ObservableObject {
+  @Published var state: ResetPasswordState = .form
+  @Published var newPassword = ""
+  @Published var confirmPassword = ""
+  @Published var isPasswordVisible = false
+  @Published var fieldErrors: [String: String] = [:]
+  @Published var successCountdown = 3
+  @Published var shouldNavigateToLogin = false
+
+  private let authManager: any AuthManaging
+  private var countdownTimer: AnyCancellable?
+
+  var passwordStrength: (isValid: Bool, errors: [String]) {
+    FormValidator.validatePasswordStrength(newPassword)
+  }
+
+  var passwordsMatch: Bool {
+    !newPassword.isEmpty && newPassword == confirmPassword
+  }
+
+  var isFormValid: Bool {
+    passwordStrength.isValid && passwordsMatch && fieldErrors.isEmpty
+  }
+
+  var isLoading: Bool {
+    state == .resetting
+  }
+
+  var isButtonDisabled: Bool {
+    isLoading || !isFormValid
+  }
+
+  init(authManager: any AuthManaging = AuthManager.shared) {
+    self.authManager = authManager
+  }
+
+  func validateNewPassword() {
+    let result = FormValidator.validatePasswordStrength(newPassword)
+    if !result.isValid {
+      fieldErrors["newPassword"] = "Password does not meet requirements"
+    } else {
+      fieldErrors["newPassword"] = nil
+    }
+
+    if !confirmPassword.isEmpty {
+      validateConfirmPassword()
+    }
+  }
+
+  func validateConfirmPassword() {
+    if let error = FormValidator.validatePasswordMatch(newPassword, confirmPassword) {
+      fieldErrors["confirmPassword"] = error
+    } else {
+      fieldErrors["confirmPassword"] = nil
+    }
+  }
+
+  func resetPassword() async {
+    state = .resetting
+    fieldErrors = [:]
+
+    validateNewPassword()
+    validateConfirmPassword()
+
+    guard isFormValid else {
+      state = .form
+      return
+    }
+
+    do {
+      try await authManager.updatePassword(newPassword: newPassword)
+      state = .success
+      startSuccessCountdown()
+    } catch {
+      let message = (error as? AuthError)?.errorDescription ?? "Failed to reset password. Please try again."
+      state = .error(message: message)
+    }
+  }
+
+  func startSuccessCountdown() {
+    successCountdown = 3
+
+    countdownTimer = Timer.publish(every: 1, on: .main, in: .common)
+      .autoconnect()
+      .sink { [weak self] _ in
+        guard let self else { return }
+        self.successCountdown -= 1
+        if self.successCountdown <= 0 {
+          self.shouldNavigateToLogin = true
+          self.countdownTimer?.cancel()
+        }
+      }
+  }
+
+  func returnToForm() {
+    state = .form
+    fieldErrors = [:]
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Views/ForgotPasswordView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Views/ForgotPasswordView.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+
+struct ForgotPasswordView: View {
+  @StateObject private var viewModel: ForgotPasswordViewModel
+  @Environment(\.dismiss) var dismiss
+  @Environment(\.sizeCategory) var sizeCategory
+
+  init(authManager: AuthManager = .shared) {
+    _viewModel = StateObject(wrappedValue: ForgotPasswordViewModel(authManager: authManager))
+  }
+
+  var body: some View {
+    ZStack {
+      LinearGradient(
+        gradient: Gradient(colors: [
+          Color(red: 0.024, green: 0.588, blue: 0.412),
+          Color(red: 0.016, green: 0.522, blue: 0.373)
+        ]),
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+      .ignoresSafeArea()
+
+      VStack(spacing: 0) {
+        HStack {
+          Button(action: { dismiss() }) {
+            HStack(spacing: 4) {
+              Image(systemName: "arrow.left")
+                .font(.footnote.weight(.semibold))
+                .accessibilityHidden(true)
+              Text("Back to Login")
+                .font(.footnote.weight(.semibold))
+            }
+            .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+          }
+          .accessibilityLabel("Back to login screen")
+          .accessibilityHint("Returns to the sign in screen")
+          Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+
+        ScrollView {
+          if viewModel.emailSent {
+            successContent
+          } else {
+            formContent
+          }
+        }
+        .background(Color.white.opacity(0.95))
+        .cornerRadius(16)
+        .padding(24)
+
+        Spacer()
+      }
+    }
+    .navigationBarBackButtonHidden(true)
+  }
+
+  // MARK: - Form State
+
+  private var formContent: some View {
+    VStack(spacing: 24) {
+      Image(systemName: "lock.rotation")
+        .font(.system(size: 48))
+        .foregroundColor(Color(red: 0.024, green: 0.588, blue: 0.412))
+        .padding(.vertical, 12)
+        .scaleEffect(sizeCategory >= .extraLarge ? 1.08 : 1.0)
+        .accessibilityHidden(true)
+
+      VStack(spacing: 8) {
+        Text("Forgot Password?")
+          .font(.title3.weight(.semibold))
+          .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+
+        Text("Enter your email and we'll send you a link to reset your password.")
+          .font(.footnote)
+          .foregroundColor(Color(red: 0.427, green: 0.467, blue: 0.514))
+          .multilineTextAlignment(.center)
+      }
+
+      if let error = viewModel.errorMessage {
+        ErrorBanner(
+          message: error,
+          onDismiss: viewModel.dismissError
+        )
+        .transition(.opacity)
+      }
+
+      LoginFormField(
+        label: "Email",
+        placeholder: "your.email@example.com",
+        icon: "envelope",
+        text: $viewModel.email,
+        error: Binding(
+          get: { viewModel.fieldErrors["email"] },
+          set: { viewModel.fieldErrors["email"] = $0 }
+        ),
+        isSecure: false,
+        keyboardType: .emailAddress,
+        onBlur: viewModel.validateEmail
+      )
+      .disabled(viewModel.isLoading)
+
+      Button(action: {
+        Task {
+          await viewModel.sendResetLink()
+        }
+      }) {
+        HStack {
+          Text(viewModel.isLoading ? "Sending..." : "Send Reset Link")
+            .font(.callout.weight(.semibold))
+
+          if viewModel.isLoading {
+            ProgressView()
+              .tint(.white)
+          }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 48)
+        .foregroundColor(.white)
+        .background(
+          LinearGradient(
+            gradient: Gradient(colors: [
+              Color(red: 0, green: 0.4, blue: 1),
+              Color(red: 0, green: 0.32, blue: 0.8)
+            ]),
+            startPoint: .leading,
+            endPoint: .trailing
+          )
+        )
+        .cornerRadius(8)
+        .opacity(viewModel.isButtonDisabled ? 0.5 : 1)
+        .disabled(viewModel.isButtonDisabled)
+      }
+      .accessibilityLabel(viewModel.isLoading ? "Sending reset link" : "Send password reset link")
+      .accessibilityHint("Sends a password reset email to your address")
+    }
+    .padding(32)
+  }
+
+  // MARK: - Success State
+
+  private var successContent: some View {
+    VStack(spacing: 24) {
+      VerificationStatusIcon(state: .verified)
+
+      VStack(spacing: 8) {
+        Text("Check Your Email")
+          .font(.title3.weight(.semibold))
+          .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+
+        Text("We've sent a password reset link to:")
+          .font(.footnote)
+          .foregroundColor(Color(red: 0.427, green: 0.467, blue: 0.514))
+
+        Text(viewModel.submittedEmail)
+          .font(.footnote.weight(.semibold))
+          .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+      }
+
+      if let error = viewModel.errorMessage {
+        ErrorBanner(
+          message: error,
+          onDismiss: viewModel.dismissError
+        )
+        .transition(.opacity)
+      }
+
+      InfoBanner(state: .pending(email: viewModel.submittedEmail))
+
+      Button(action: {
+        Task {
+          await viewModel.resendResetLink()
+        }
+      }) {
+        HStack {
+          if viewModel.isLoading {
+            ProgressView()
+              .tint(Color(red: 0.149, green: 0.388, blue: 0.931))
+          }
+          Text(resendButtonText)
+            .font(.callout.weight(.semibold))
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 48)
+        .foregroundColor(Color(red: 0.149, green: 0.388, blue: 0.931))
+        .background(Color(red: 0.149, green: 0.388, blue: 0.931).opacity(0.1))
+        .cornerRadius(8)
+        .opacity(viewModel.canResendEmail ? 1 : 0.5)
+      }
+      .disabled(!viewModel.canResendEmail || viewModel.isLoading)
+      .accessibilityLabel(resendButtonAccessibilityLabel)
+
+      Button(action: { viewModel.resetForm() }) {
+        Text("Use Different Email")
+          .font(.footnote.weight(.semibold))
+          .foregroundColor(Color(red: 0.149, green: 0.388, blue: 0.931))
+          .frame(minHeight: 44)
+          .contentShape(Rectangle())
+      }
+      .accessibilityLabel("Use a different email address")
+      .accessibilityHint("Returns to the email form")
+
+      Button(action: { dismiss() }) {
+        HStack(spacing: 4) {
+          Image(systemName: "arrow.left")
+            .font(.caption.weight(.semibold))
+            .accessibilityHidden(true)
+          Text("Back to Login")
+            .font(.footnote.weight(.semibold))
+        }
+        .foregroundColor(Color(red: 0.282, green: 0.337, blue: 0.431))
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
+      }
+      .accessibilityLabel("Back to login screen")
+    }
+    .padding(32)
+  }
+
+  private var resendButtonText: String {
+    if !viewModel.canResendEmail {
+      return "Send Another (\(viewModel.resendCooldownSeconds)s)"
+    }
+    return "Send Another"
+  }
+
+  private var resendButtonAccessibilityLabel: String {
+    if !viewModel.canResendEmail {
+      return "Send another reset link, available in \(viewModel.resendCooldownSeconds) seconds"
+    }
+    return "Send another reset link"
+  }
+}
+
+#Preview {
+  NavigationStack {
+    ForgotPasswordView()
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Views/LoginView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Views/LoginView.swift
@@ -122,7 +122,7 @@ struct LoginView: View {
 
               Spacer()
 
-              NavigationLink(value: "forgot-password") {
+              NavigationLink(destination: ForgotPasswordView()) {
                 Text("Forgot password?")
                   .font(.footnote)
                   .foregroundColor(Color(red: 0.282, green: 0.337, blue: 0.431))

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Views/ResetPasswordView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Auth/Views/ResetPasswordView.swift
@@ -1,0 +1,294 @@
+import SwiftUI
+
+struct ResetPasswordView: View {
+  @StateObject private var viewModel: ResetPasswordViewModel
+  @Environment(\.dismiss) var dismiss
+  @Environment(\.sizeCategory) var sizeCategory
+
+  init(authManager: AuthManager = .shared) {
+    _viewModel = StateObject(wrappedValue: ResetPasswordViewModel(authManager: authManager))
+  }
+
+  var body: some View {
+    ZStack {
+      LinearGradient(
+        gradient: Gradient(colors: [
+          Color(red: 0.024, green: 0.588, blue: 0.412),
+          Color(red: 0.016, green: 0.522, blue: 0.373)
+        ]),
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+      .ignoresSafeArea()
+
+      VStack(spacing: 0) {
+        HStack {
+          Button(action: { dismiss() }) {
+            HStack(spacing: 4) {
+              Image(systemName: "arrow.left")
+                .font(.footnote.weight(.semibold))
+                .accessibilityHidden(true)
+              Text("Back")
+                .font(.footnote.weight(.semibold))
+            }
+            .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+          }
+          .accessibilityLabel("Back to previous screen")
+          Spacer()
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+
+        ScrollView {
+          Group {
+            switch viewModel.state {
+            case .form:
+              formContent
+            case .resetting:
+              formContent
+            case .success:
+              successContent
+            case .error(let message):
+              errorContent(message: message)
+            }
+          }
+        }
+        .background(Color.white.opacity(0.95))
+        .cornerRadius(16)
+        .padding(24)
+
+        Spacer()
+      }
+    }
+    .navigationBarBackButtonHidden(true)
+    .onChange(of: viewModel.shouldNavigateToLogin) { _, shouldNavigate in
+      if shouldNavigate {
+        dismiss()
+      }
+    }
+  }
+
+  // MARK: - Form State
+
+  private var formContent: some View {
+    VStack(spacing: 24) {
+      Image(systemName: "lock.rotation")
+        .font(.system(size: 48))
+        .foregroundColor(Color(red: 0.024, green: 0.588, blue: 0.412))
+        .padding(.vertical, 12)
+        .scaleEffect(sizeCategory >= .extraLarge ? 1.08 : 1.0)
+        .accessibilityHidden(true)
+
+      VStack(spacing: 8) {
+        Text("Reset Password")
+          .font(.title3.weight(.semibold))
+          .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+
+        Text("Enter your new password below.")
+          .font(.footnote)
+          .foregroundColor(Color(red: 0.427, green: 0.467, blue: 0.514))
+      }
+
+      PasswordFormField(
+        label: "New Password",
+        placeholder: "Enter your new password",
+        text: $viewModel.newPassword,
+        error: Binding(
+          get: { viewModel.fieldErrors["newPassword"] },
+          set: { viewModel.fieldErrors["newPassword"] = $0 }
+        ),
+        isPasswordVisible: $viewModel.isPasswordVisible,
+        onBlur: viewModel.validateNewPassword
+      )
+      .disabled(viewModel.isLoading)
+
+      PasswordStrengthIndicator(password: viewModel.newPassword)
+        .padding(.horizontal, 16)
+
+      PasswordFormField(
+        label: "Confirm Password",
+        placeholder: "Re-enter your new password",
+        text: $viewModel.confirmPassword,
+        error: Binding(
+          get: { viewModel.fieldErrors["confirmPassword"] },
+          set: { viewModel.fieldErrors["confirmPassword"] = $0 }
+        ),
+        isPasswordVisible: $viewModel.isPasswordVisible,
+        onBlur: viewModel.validateConfirmPassword
+      )
+      .disabled(viewModel.isLoading)
+
+      if !viewModel.confirmPassword.isEmpty {
+        passwordMatchIndicator
+      }
+
+      Button(action: {
+        Task {
+          await viewModel.resetPassword()
+        }
+      }) {
+        HStack {
+          Text(viewModel.isLoading ? "Resetting..." : "Reset Password")
+            .font(.callout.weight(.semibold))
+
+          if viewModel.isLoading {
+            ProgressView()
+              .tint(.white)
+          }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 48)
+        .foregroundColor(.white)
+        .background(
+          LinearGradient(
+            gradient: Gradient(colors: [
+              Color(red: 0, green: 0.4, blue: 1),
+              Color(red: 0, green: 0.32, blue: 0.8)
+            ]),
+            startPoint: .leading,
+            endPoint: .trailing
+          )
+        )
+        .cornerRadius(8)
+        .opacity(viewModel.isButtonDisabled ? 0.5 : 1)
+        .disabled(viewModel.isButtonDisabled)
+      }
+      .accessibilityLabel(viewModel.isLoading ? "Resetting password" : "Reset password")
+      .accessibilityHint("Sets your new password")
+    }
+    .padding(32)
+  }
+
+  // MARK: - Password Match Indicator
+
+  private var passwordMatchIndicator: some View {
+    HStack(spacing: 6) {
+      Image(systemName: viewModel.passwordsMatch ? "checkmark.circle.fill" : "xmark.circle.fill")
+        .foregroundColor(viewModel.passwordsMatch
+          ? Color(red: 0.2, green: 0.62, blue: 0.4)
+          : Color(red: 0.859, green: 0.149, blue: 0.149))
+        .accessibilityHidden(true)
+
+      Text(viewModel.passwordsMatch ? "Passwords match" : "Passwords do not match")
+        .font(.caption)
+        .foregroundColor(viewModel.passwordsMatch
+          ? Color(red: 0.2, green: 0.62, blue: 0.4)
+          : Color(red: 0.859, green: 0.149, blue: 0.149))
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(viewModel.passwordsMatch ? "Passwords match" : "Passwords do not match")
+  }
+
+  // MARK: - Success State
+
+  private var successContent: some View {
+    VStack(spacing: 24) {
+      VerificationStatusIcon(state: .verified)
+
+      VStack(spacing: 8) {
+        Text("Password Reset!")
+          .font(.title3.weight(.semibold))
+          .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+
+        Text("Your password has been updated successfully.")
+          .font(.footnote)
+          .foregroundColor(Color(red: 0.427, green: 0.467, blue: 0.514))
+          .multilineTextAlignment(.center)
+      }
+
+      InfoBanner(state: .verified)
+
+      Text("Redirecting to login in \(viewModel.successCountdown)s...")
+        .font(.caption)
+        .foregroundColor(Color(red: 0.427, green: 0.467, blue: 0.514))
+        .accessibilityLabel("Redirecting to login in \(viewModel.successCountdown) seconds")
+
+      Button(action: { dismiss() }) {
+        Text("Sign In Now")
+          .font(.callout.weight(.semibold))
+          .frame(maxWidth: .infinity)
+          .frame(height: 48)
+          .foregroundColor(.white)
+          .background(
+            LinearGradient(
+              gradient: Gradient(colors: [
+                Color(red: 0, green: 0.4, blue: 1),
+                Color(red: 0, green: 0.32, blue: 0.8)
+              ]),
+              startPoint: .leading,
+              endPoint: .trailing
+            )
+          )
+          .cornerRadius(8)
+      }
+      .accessibilityLabel("Sign in now")
+      .accessibilityHint("Navigate to the login screen")
+    }
+    .padding(32)
+  }
+
+  // MARK: - Error State
+
+  private func errorContent(message: String) -> some View {
+    VStack(spacing: 24) {
+      VerificationStatusIcon(state: .error(message: message))
+
+      VStack(spacing: 8) {
+        Text("Invalid Link")
+          .font(.title3.weight(.semibold))
+          .foregroundColor(Color(red: 0.216, green: 0.263, blue: 0.322))
+
+        Text("This password reset link is no longer valid.")
+          .font(.footnote)
+          .foregroundColor(Color(red: 0.427, green: 0.467, blue: 0.514))
+          .multilineTextAlignment(.center)
+      }
+
+      ErrorBanner(
+        message: message,
+        onDismiss: {}
+      )
+
+      NavigationLink(destination: ForgotPasswordView()) {
+        Text("Request New Link")
+          .font(.callout.weight(.semibold))
+          .frame(maxWidth: .infinity)
+          .frame(height: 48)
+          .foregroundColor(.white)
+          .background(
+            LinearGradient(
+              gradient: Gradient(colors: [
+                Color(red: 0, green: 0.4, blue: 1),
+                Color(red: 0, green: 0.32, blue: 0.8)
+              ]),
+              startPoint: .leading,
+              endPoint: .trailing
+            )
+          )
+          .cornerRadius(8)
+      }
+      .accessibilityLabel("Request a new password reset link")
+
+      Button(action: { dismiss() }) {
+        HStack(spacing: 4) {
+          Image(systemName: "arrow.left")
+            .font(.caption.weight(.semibold))
+            .accessibilityHidden(true)
+          Text("Back to Login")
+            .font(.footnote.weight(.semibold))
+        }
+        .foregroundColor(Color(red: 0.282, green: 0.337, blue: 0.431))
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
+      }
+      .accessibilityLabel("Back to login screen")
+    }
+    .padding(32)
+  }
+}
+
+#Preview {
+  NavigationStack {
+    ResetPasswordView()
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/TheRecruitingCompassApp.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/TheRecruitingCompassApp.swift
@@ -11,6 +11,7 @@ import Supabase
 @main
 struct TheRecruitingCompassApp: App {
   @StateObject var authManager = AuthManager.shared
+  @State private var showResetPassword = false
 
   var body: some Scene {
     WindowGroup {
@@ -29,8 +30,26 @@ struct TheRecruitingCompassApp: App {
       }
       .animation(.easeInOut(duration: 0.3), value: authManager.isAuthenticated)
       .animation(.easeInOut(duration: 0.2), value: authManager.isCheckingSession)
+      .onOpenURL { url in
+        handleDeepLink(url)
+      }
+      .sheet(isPresented: $showResetPassword) {
+        NavigationStack {
+          ResetPasswordView(authManager: authManager)
+        }
+      }
     }
     .environmentObject(authManager)
+  }
+
+  private func handleDeepLink(_ url: URL) {
+    let route = DeepLinkHandler.parse(url)
+    switch route {
+    case .resetPassword:
+      showResetPassword = true
+    case .unknown:
+      break
+    }
   }
 
   private var sessionLoadingView: some View {

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Core/Utilities/DeepLinkHandlerTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Core/Utilities/DeepLinkHandlerTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import TheRecruitingCompass
+
+final class DeepLinkHandlerTests: XCTestCase {
+
+  func testValidResetPasswordURL() {
+    let url = URL(string: "recruiting-compass://reset-password?token=abc123")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .resetPassword(token: "abc123"))
+  }
+
+  func testMissingToken() {
+    let url = URL(string: "recruiting-compass://reset-password")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .unknown)
+  }
+
+  func testEmptyToken() {
+    let url = URL(string: "recruiting-compass://reset-password?token=")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .unknown)
+  }
+
+  func testWrongScheme() {
+    let url = URL(string: "https://reset-password?token=abc123")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .unknown)
+  }
+
+  func testWrongHost() {
+    let url = URL(string: "recruiting-compass://verify-email?token=abc123")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .unknown)
+  }
+
+  func testTokenWithSpecialCharacters() {
+    let url = URL(string: "recruiting-compass://reset-password?token=abc-123_def.456")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .resetPassword(token: "abc-123_def.456"))
+  }
+
+  func testMultipleQueryParams() {
+    let url = URL(string: "recruiting-compass://reset-password?token=abc123&extra=value")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .resetPassword(token: "abc123"))
+  }
+
+  func testTokenOnlyNoQueryParamName() {
+    let url = URL(string: "recruiting-compass://reset-password?abc123")!
+    let route = DeepLinkHandler.parse(url)
+    XCTAssertEqual(route, .unknown)
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Auth/ViewModels/ForgotPasswordViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Auth/ViewModels/ForgotPasswordViewModelTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import TheRecruitingCompass
+
+@MainActor
+final class ForgotPasswordViewModelTests: XCTestCase {
+  var sut: ForgotPasswordViewModel!
+  var mockAuthManager: MockAuthManager!
+
+  override func setUp() {
+    super.setUp()
+    mockAuthManager = MockAuthManager()
+    sut = ForgotPasswordViewModel(authManager: mockAuthManager)
+  }
+
+  override func tearDown() {
+    sut = nil
+    mockAuthManager = nil
+    super.tearDown()
+  }
+
+  // MARK: - Initial State
+
+  func testInitialState() {
+    XCTAssertEqual(sut.email, "")
+    XCTAssertFalse(sut.isLoading)
+    XCTAssertFalse(sut.emailSent)
+    XCTAssertEqual(sut.submittedEmail, "")
+    XCTAssertNil(sut.errorMessage)
+    XCTAssertTrue(sut.fieldErrors.isEmpty)
+    XCTAssertTrue(sut.canResendEmail)
+    XCTAssertEqual(sut.resendCooldownSeconds, 0)
+  }
+
+  // MARK: - Validation
+
+  func testValidateEmailWithValidEmail() {
+    sut.email = "user@example.com"
+    sut.validateEmail()
+    XCTAssertNil(sut.fieldErrors["email"])
+  }
+
+  func testValidateEmailWithEmptyEmail() {
+    sut.email = ""
+    sut.validateEmail()
+    XCTAssertNotNil(sut.fieldErrors["email"])
+  }
+
+  func testValidateEmailWithInvalidEmail() {
+    sut.email = "not-an-email"
+    sut.validateEmail()
+    XCTAssertNotNil(sut.fieldErrors["email"])
+  }
+
+  // MARK: - Form Valid
+
+  func testIsFormValidWithValidEmail() {
+    sut.email = "user@example.com"
+    XCTAssertTrue(sut.isFormValid)
+  }
+
+  func testIsFormValidWithEmptyEmail() {
+    sut.email = ""
+    XCTAssertFalse(sut.isFormValid)
+  }
+
+  func testIsFormValidWithFieldErrors() {
+    sut.email = "user@example.com"
+    sut.fieldErrors["email"] = "Invalid"
+    XCTAssertFalse(sut.isFormValid)
+  }
+
+  // MARK: - Button Disabled
+
+  func testButtonDisabledWhenLoading() {
+    sut.email = "user@example.com"
+    sut.isLoading = true
+    XCTAssertTrue(sut.isButtonDisabled)
+  }
+
+  func testButtonDisabledWhenFormInvalid() {
+    sut.email = ""
+    XCTAssertTrue(sut.isButtonDisabled)
+  }
+
+  func testButtonEnabledWhenFormValid() {
+    sut.email = "user@example.com"
+    XCTAssertFalse(sut.isButtonDisabled)
+  }
+
+  // MARK: - Send Reset Link
+
+  func testSendResetLinkSuccess() async {
+    sut.email = "user@example.com"
+    await sut.sendResetLink()
+
+    XCTAssertEqual(mockAuthManager.resetEmailCallCount, 1)
+    XCTAssertTrue(sut.emailSent)
+    XCTAssertEqual(sut.submittedEmail, "user@example.com")
+    XCTAssertNil(sut.errorMessage)
+    XCTAssertFalse(sut.isLoading)
+  }
+
+  func testSendResetLinkFailure() async {
+    mockAuthManager.shouldThrowResetEmailError = true
+    mockAuthManager.mockErrorToThrow = .resetEmailNotFound
+
+    sut.email = "unknown@example.com"
+    await sut.sendResetLink()
+
+    XCTAssertEqual(mockAuthManager.resetEmailCallCount, 1)
+    XCTAssertFalse(sut.emailSent)
+    XCTAssertNotNil(sut.errorMessage)
+    XCTAssertFalse(sut.isLoading)
+  }
+
+  func testSendResetLinkWithInvalidEmail() async {
+    sut.email = "not-valid"
+    await sut.sendResetLink()
+
+    XCTAssertEqual(mockAuthManager.resetEmailCallCount, 0)
+    XCTAssertFalse(sut.emailSent)
+  }
+
+  // MARK: - Resend
+
+  func testResendResetLinkSuccess() async {
+    sut.submittedEmail = "user@example.com"
+    sut.emailSent = true
+
+    await sut.resendResetLink()
+
+    XCTAssertEqual(mockAuthManager.resetEmailCallCount, 1)
+    XCTAssertFalse(sut.canResendEmail)
+    XCTAssertEqual(sut.resendCooldownSeconds, 60)
+  }
+
+  func testResendResetLinkWhenCooldownActive() async {
+    sut.canResendEmail = false
+    sut.submittedEmail = "user@example.com"
+
+    await sut.resendResetLink()
+
+    XCTAssertEqual(mockAuthManager.resetEmailCallCount, 0)
+  }
+
+  func testResendResetLinkFailure() async {
+    mockAuthManager.shouldThrowResetEmailError = true
+    mockAuthManager.mockErrorToThrow = .networkError("Network error")
+
+    sut.submittedEmail = "user@example.com"
+    sut.emailSent = true
+
+    await sut.resendResetLink()
+
+    XCTAssertEqual(mockAuthManager.resetEmailCallCount, 1)
+    XCTAssertNotNil(sut.errorMessage)
+  }
+
+  // MARK: - Reset Form
+
+  func testResetFormClearsState() {
+    sut.emailSent = true
+    sut.submittedEmail = "user@example.com"
+    sut.errorMessage = "Some error"
+    sut.fieldErrors["email"] = "Invalid"
+
+    sut.resetForm()
+
+    XCTAssertFalse(sut.emailSent)
+    XCTAssertEqual(sut.submittedEmail, "")
+    XCTAssertNil(sut.errorMessage)
+    XCTAssertTrue(sut.fieldErrors.isEmpty)
+  }
+
+  // MARK: - Dismiss Error
+
+  func testDismissError() {
+    sut.errorMessage = "Some error"
+    sut.dismissError()
+    XCTAssertNil(sut.errorMessage)
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Auth/ViewModels/ResetPasswordViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Auth/ViewModels/ResetPasswordViewModelTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+@testable import TheRecruitingCompass
+
+@MainActor
+final class ResetPasswordViewModelTests: XCTestCase {
+  var sut: ResetPasswordViewModel!
+  var mockAuthManager: MockAuthManager!
+
+  override func setUp() {
+    super.setUp()
+    mockAuthManager = MockAuthManager()
+    sut = ResetPasswordViewModel(authManager: mockAuthManager)
+  }
+
+  override func tearDown() {
+    sut = nil
+    mockAuthManager = nil
+    super.tearDown()
+  }
+
+  // MARK: - Initial State
+
+  func testInitialState() {
+    XCTAssertEqual(sut.state, .form)
+    XCTAssertEqual(sut.newPassword, "")
+    XCTAssertEqual(sut.confirmPassword, "")
+    XCTAssertFalse(sut.isPasswordVisible)
+    XCTAssertTrue(sut.fieldErrors.isEmpty)
+    XCTAssertEqual(sut.successCountdown, 3)
+    XCTAssertFalse(sut.shouldNavigateToLogin)
+  }
+
+  // MARK: - Password Strength
+
+  func testPasswordStrengthWeak() {
+    sut.newPassword = "weak"
+    XCTAssertFalse(sut.passwordStrength.isValid)
+    XCTAssertFalse(sut.passwordStrength.errors.isEmpty)
+  }
+
+  func testPasswordStrengthStrong() {
+    sut.newPassword = "StrongPass1"
+    XCTAssertTrue(sut.passwordStrength.isValid)
+    XCTAssertTrue(sut.passwordStrength.errors.isEmpty)
+  }
+
+  // MARK: - Passwords Match
+
+  func testPasswordsMatchWhenEqual() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+    XCTAssertTrue(sut.passwordsMatch)
+  }
+
+  func testPasswordsDoNotMatch() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "Different1"
+    XCTAssertFalse(sut.passwordsMatch)
+  }
+
+  func testPasswordsMatchEmptyNewPassword() {
+    sut.newPassword = ""
+    sut.confirmPassword = ""
+    XCTAssertFalse(sut.passwordsMatch)
+  }
+
+  // MARK: - Form Valid
+
+  func testIsFormValidWhenStrongAndMatching() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+    XCTAssertTrue(sut.isFormValid)
+  }
+
+  func testIsFormInvalidWhenWeak() {
+    sut.newPassword = "weak"
+    sut.confirmPassword = "weak"
+    XCTAssertFalse(sut.isFormValid)
+  }
+
+  func testIsFormInvalidWhenNotMatching() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "DifferentPass1"
+    XCTAssertFalse(sut.isFormValid)
+  }
+
+  func testIsFormInvalidWithFieldErrors() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+    sut.fieldErrors["newPassword"] = "Error"
+    XCTAssertFalse(sut.isFormValid)
+  }
+
+  // MARK: - Button Disabled
+
+  func testButtonDisabledWhenResetting() {
+    sut.state = .resetting
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+    XCTAssertTrue(sut.isButtonDisabled)
+  }
+
+  func testButtonDisabledWhenFormInvalid() {
+    sut.newPassword = ""
+    XCTAssertTrue(sut.isButtonDisabled)
+  }
+
+  func testButtonEnabledWhenFormValid() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+    XCTAssertFalse(sut.isButtonDisabled)
+  }
+
+  // MARK: - Validate New Password
+
+  func testValidateNewPasswordWeak() {
+    sut.newPassword = "weak"
+    sut.validateNewPassword()
+    XCTAssertNotNil(sut.fieldErrors["newPassword"])
+  }
+
+  func testValidateNewPasswordStrong() {
+    sut.newPassword = "StrongPass1"
+    sut.validateNewPassword()
+    XCTAssertNil(sut.fieldErrors["newPassword"])
+  }
+
+  func testValidateNewPasswordAlsoValidatesConfirmWhenNotEmpty() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "OtherPass1"
+    sut.validateNewPassword()
+    XCTAssertNotNil(sut.fieldErrors["confirmPassword"])
+  }
+
+  // MARK: - Validate Confirm Password
+
+  func testValidateConfirmPasswordMatch() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+    sut.validateConfirmPassword()
+    XCTAssertNil(sut.fieldErrors["confirmPassword"])
+  }
+
+  func testValidateConfirmPasswordNoMatch() {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "Different1"
+    sut.validateConfirmPassword()
+    XCTAssertNotNil(sut.fieldErrors["confirmPassword"])
+  }
+
+  // MARK: - Reset Password
+
+  func testResetPasswordSuccess() async {
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+
+    await sut.resetPassword()
+
+    XCTAssertEqual(mockAuthManager.updatePasswordCallCount, 1)
+    XCTAssertEqual(sut.state, .success)
+  }
+
+  func testResetPasswordFailure() async {
+    mockAuthManager.shouldThrowUpdatePasswordError = true
+    mockAuthManager.mockErrorToThrow = .invalidResetToken
+
+    sut.newPassword = "StrongPass1"
+    sut.confirmPassword = "StrongPass1"
+
+    await sut.resetPassword()
+
+    XCTAssertEqual(mockAuthManager.updatePasswordCallCount, 1)
+    if case .error(let message) = sut.state {
+      XCTAssertFalse(message.isEmpty)
+    } else {
+      XCTFail("Expected error state")
+    }
+  }
+
+  func testResetPasswordWithInvalidForm() async {
+    sut.newPassword = "weak"
+    sut.confirmPassword = "weak"
+
+    await sut.resetPassword()
+
+    XCTAssertEqual(mockAuthManager.updatePasswordCallCount, 0)
+    XCTAssertEqual(sut.state, .form)
+  }
+
+  // MARK: - Success Countdown
+
+  func testStartSuccessCountdown() {
+    sut.startSuccessCountdown()
+    XCTAssertEqual(sut.successCountdown, 3)
+  }
+
+  // MARK: - Return To Form
+
+  func testReturnToForm() {
+    sut.state = .error(message: "Error")
+    sut.fieldErrors["newPassword"] = "Error"
+
+    sut.returnToForm()
+
+    XCTAssertEqual(sut.state, .form)
+    XCTAssertTrue(sut.fieldErrors.isEmpty)
+  }
+
+  // MARK: - Is Loading
+
+  func testIsLoadingWhenResetting() {
+    sut.state = .resetting
+    XCTAssertTrue(sut.isLoading)
+  }
+
+  func testIsNotLoadingWhenForm() {
+    sut.state = .form
+    XCTAssertFalse(sut.isLoading)
+  }
+
+  func testIsNotLoadingWhenSuccess() {
+    sut.state = .success
+    XCTAssertFalse(sut.isLoading)
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Mocks/MockAuthManager.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Mocks/MockAuthManager.swift
@@ -21,6 +21,11 @@ class MockAuthManager: AuthManaging {
   var shouldThrowResendError = false
   var shouldThrowLoginError = false
   var shouldThrowSignupError = false
+  var shouldThrowResetEmailError = false
+  var shouldThrowUpdatePasswordError = false
+
+  var resetEmailCallCount = 0
+  var updatePasswordCallCount = 0
 
   var mockUserToReturn: User?
   var mockSessionToReturn: Session?
@@ -121,6 +126,20 @@ class MockAuthManager: AuthManaging {
     }
   }
 
+  func resetPasswordForEmail(email: String) async throws {
+    resetEmailCallCount += 1
+    if shouldThrowResetEmailError {
+      throw mockErrorToThrow
+    }
+  }
+
+  func updatePassword(newPassword: String) async throws {
+    updatePasswordCallCount += 1
+    if shouldThrowUpdatePasswordError {
+      throw mockErrorToThrow
+    }
+  }
+
   func logout() async throws {
     self.user = nil
     self.session = nil
@@ -151,6 +170,10 @@ class MockAuthManager: AuthManaging {
     shouldThrowResendError = false
     shouldThrowLoginError = false
     shouldThrowSignupError = false
+    shouldThrowResetEmailError = false
+    shouldThrowUpdatePasswordError = false
+    resetEmailCallCount = 0
+    updatePasswordCallCount = 0
 
     user = nil
     mockUserToReturn = nil


### PR DESCRIPTION
…eens

Complete password recovery implementation including:
- ForgotPasswordView with email submission and resend cooldown
- ResetPasswordView with state machine (form/resetting/success/error)
- PasswordFormField component with show/hide toggle
- DeepLinkHandler for recruiting-compass:// URL scheme
- AuthManaging protocol extended with resetPasswordForEmail and updatePassword
- AuthError cases for invalidResetToken, expiredResetToken, resetEmailNotFound
- Deep link handling wired into app entry point
- 52 new tests (26 ResetPasswordVM + 18 ForgotPasswordVM + 8 DeepLink)