### PR TITLE
feat: log coach outreach only on confirmed in-app send

### DIFF
--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Components/MailComposeView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Components/MailComposeView.swift
@@ -1,0 +1,45 @@
+import MessageUI
+import SwiftUI
+
+/// SwiftUI wrapper around `MFMailComposeViewController` — an in-app mail composer that reports a
+/// real send result. Present ONLY after checking `MFMailComposeViewController.canSendMail()`;
+/// with no Mail account the composer cannot send. `onResult` fires once with the final result.
+struct MailComposeView: UIViewControllerRepresentable {
+  let recipients: [String]
+  let subject: String?
+  let body: String?
+  let onResult: (MFMailComposeResult, Error?) -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(onResult: onResult)
+  }
+
+  func makeUIViewController(context: Context) -> MFMailComposeViewController {
+    let controller = MFMailComposeViewController()
+    controller.mailComposeDelegate = context.coordinator
+    controller.setToRecipients(recipients.filter { !$0.isEmpty })
+    if let subject, !subject.isEmpty { controller.setSubject(subject) }
+    if let body, !body.isEmpty { controller.setMessageBody(body, isHTML: false) }
+    return controller
+  }
+
+  func updateUIViewController(_ controller: MFMailComposeViewController, context: Context) {}
+
+  final class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+    private let onResult: (MFMailComposeResult, Error?) -> Void
+
+    init(onResult: @escaping (MFMailComposeResult, Error?) -> Void) {
+      self.onResult = onResult
+    }
+
+    func mailComposeController(
+      _ controller: MFMailComposeViewController,
+      didFinishWith result: MFMailComposeResult,
+      error: Error?
+    ) {
+      controller.dismiss(animated: true) { [onResult] in
+        onResult(result, error)
+      }
+    }
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Components/MessageComposeView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Components/MessageComposeView.swift
@@ -1,0 +1,42 @@
+import MessageUI
+import SwiftUI
+
+/// SwiftUI wrapper around `MFMessageComposeViewController` — an in-app text composer that reports a
+/// real send result. Present ONLY after checking `MFMessageComposeViewController.canSendText()`.
+/// `onResult` fires once with the final result.
+struct MessageComposeView: UIViewControllerRepresentable {
+  let recipients: [String]
+  let body: String?
+  let onResult: (MessageComposeResult) -> Void
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(onResult: onResult)
+  }
+
+  func makeUIViewController(context: Context) -> MFMessageComposeViewController {
+    let controller = MFMessageComposeViewController()
+    controller.messageComposeDelegate = context.coordinator
+    controller.recipients = recipients.filter { !$0.isEmpty }
+    if let body, !body.isEmpty { controller.body = body }
+    return controller
+  }
+
+  func updateUIViewController(_ controller: MFMessageComposeViewController, context: Context) {}
+
+  final class Coordinator: NSObject, MFMessageComposeViewControllerDelegate {
+    private let onResult: (MessageComposeResult) -> Void
+
+    init(onResult: @escaping (MessageComposeResult) -> Void) {
+      self.onResult = onResult
+    }
+
+    func messageComposeViewController(
+      _ controller: MFMessageComposeViewController,
+      didFinishWith result: MessageComposeResult
+    ) {
+      controller.dismiss(animated: true) { [onResult] in
+        onResult(result)
+      }
+    }
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Models/CoachUpdateRequest.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Models/CoachUpdateRequest.swift
@@ -11,6 +11,7 @@ struct CoachUpdateRequest: Codable, Sendable {
   let notes: String?
   let nextContactDate: String?
   let followUpThresholdDays: Int?
+  let lastContactDate: String?
 
   enum CodingKeys: String, CodingKey {
     case firstName = "first_name"
@@ -21,5 +22,34 @@ struct CoachUpdateRequest: Codable, Sendable {
     case notes
     case nextContactDate = "next_contact_date"
     case followUpThresholdDays = "follow_up_threshold_days"
+    case lastContactDate = "last_contact_date"
+  }
+
+  /// All fields default to nil so callers can update a single field (e.g. `CoachUpdateRequest(lastContactDate:)`)
+  /// without listing the rest. Only non-nil fields are meaningful to the update.
+  init(
+    firstName: String? = nil,
+    lastName: String? = nil,
+    email: String? = nil,
+    phone: String? = nil,
+    position: String? = nil,
+    twitterHandle: String? = nil,
+    instagramHandle: String? = nil,
+    notes: String? = nil,
+    nextContactDate: String? = nil,
+    followUpThresholdDays: Int? = nil,
+    lastContactDate: String? = nil
+  ) {
+    self.firstName = firstName
+    self.lastName = lastName
+    self.email = email
+    self.phone = phone
+    self.position = position
+    self.twitterHandle = twitterHandle
+    self.instagramHandle = instagramHandle
+    self.notes = notes
+    self.nextContactDate = nextContactDate
+    self.followUpThresholdDays = followUpThresholdDays
+    self.lastContactDate = lastContactDate
   }
 }

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/ViewModels/QuickCommunicationViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/ViewModels/QuickCommunicationViewModel.swift
@@ -17,10 +17,30 @@ final class QuickCommunicationViewModel {
   var isLoading = false
   var errorMessage: String?
 
+  /// Set true after a confirmed send is logged. Drives the parent success toast.
+  var didLogSend = false
+  /// Success toast copy for a confirmed, logged send (nil until one is logged).
+  var successMessage: String?
+
   let coach: Coach
   let schoolName: String?
 
+  /// Channel a confirmed send used, so logging picks the matching interaction type.
+  enum SendChannel { case email, text }
+
   private let templatesService: any CommunicationTemplatesServicing
+  private let interactionsService: any InteractionsManaging
+  private let coachesService: any CoachesManaging
+  private var loggedBy: String?
+  private var familyUnitId: String?
+
+  /// Supply the signed-in user + family context resolved from the environment at the
+  /// presentation site (the sheet call sites don't inject the ViewModel). Safe to call
+  /// before any send; no-ops nothing already set by `init` for tests.
+  func configureContext(loggedBy: String?, familyUnitId: String?) {
+    self.loggedBy = loggedBy
+    self.familyUnitId = familyUnitId
+  }
 
   var recipientLine: String {
     "\(coach.fullName) – \(coach.role.displayName)"
@@ -52,11 +72,19 @@ final class QuickCommunicationViewModel {
   init(
     coach: Coach,
     schoolName: String? = nil,
-    templatesService: (any CommunicationTemplatesServicing)? = nil
+    templatesService: (any CommunicationTemplatesServicing)? = nil,
+    interactionsService: (any InteractionsManaging)? = nil,
+    coachesService: (any CoachesManaging)? = nil,
+    loggedBy: String? = nil,
+    familyUnitId: String? = nil
   ) {
     self.coach = coach
     self.schoolName = schoolName
     self.templatesService = templatesService ?? CommunicationTemplatesServiceImpl()
+    self.interactionsService = interactionsService ?? InteractionsServiceImpl(supabaseManager: .shared)
+    self.coachesService = coachesService ?? CoachesServiceImpl(supabaseManager: .shared)
+    self.loggedBy = loggedBy
+    self.familyUnitId = familyUnitId
   }
 
   func loadTemplates() async {
@@ -113,6 +141,59 @@ final class QuickCommunicationViewModel {
     if body.count <= Self.maxURLBodyLength { return body }
     let trimmed = String(body.prefix(Self.maxURLBodyLength - 30))
     return trimmed.trimmingCharacters(in: .whitespacesAndNewlines) + "\n\n[Message truncated — full text in app]"
+  }
+
+  // MARK: - Send logging
+
+  /// Log an outbound interaction for a message the in-app composer confirmed as `.sent`.
+  /// Call ONLY on a confirmed send — never on `.cancelled`/`.saved`/`.failed` or the no-account
+  /// fallback, so the app never records a message that wasn't actually sent.
+  func logSend(_ channel: SendChannel) async {
+    guard let loggedBy, let familyUnitId else {
+      logger.error("Cannot log sent interaction: missing user or family context")
+      errorMessage = String(localized: "Message sent, but logging it failed.")
+      return
+    }
+
+    do {
+      let request = InteractionCreateRequest(
+        schoolId: coach.schoolId,
+        coachId: coach.id,
+        type: channel == .email ? .email : .text,
+        direction: .outbound,
+        occurredAt: Date(),
+        subject: selectedTemplate?.name,
+        content: filledBody.isEmpty ? nil : filledBody,
+        sentiment: nil,
+        loggedBy: loggedBy,
+        familyUnitId: familyUnitId
+      )
+      _ = try await interactionsService.createInteraction(request)
+      await updateLastContactDate()
+
+      await InMemoryCache.shared.remove(forKey: ListCacheKeys.interactionsForFamily(familyUnitId: familyUnitId))
+      await InMemoryCache.shared.remove(forKey: ListCacheKeys.interactionsForAthlete(userId: loggedBy))
+
+      successMessage = channel == .email
+        ? String(localized: "Logged email to Coach \(coach.fullName).")
+        : String(localized: "Logged text to Coach \(coach.fullName).")
+      didLogSend = true
+      logger.info("Logged \(channel == .email ? "email" : "text") send to coach \(self.coach.id, privacy: .public)")
+    } catch {
+      logger.error("Failed to log sent interaction: \(error.localizedDescription)")
+      errorMessage = String(localized: "Message sent, but logging it failed.")
+    }
+  }
+
+  /// Stamp the coach's `last_contact_date` (parity with web; no DB trigger sets it).
+  /// A failure here does not fail the send-log — the interaction row is the source of truth.
+  private func updateLastContactDate() async {
+    do {
+      let iso = ISO8601DateFormatter().string(from: Date())
+      _ = try await coachesService.updateCoach(id: coach.id, updates: CoachUpdateRequest(lastContactDate: iso))
+    } catch {
+      logger.error("Failed to update last_contact_date: \(error.localizedDescription)")
+    }
   }
 
 }

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Views/QuickCommunicationView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Coaches/Views/QuickCommunicationView.swift
@@ -1,3 +1,4 @@
+import MessageUI
 import SwiftUI
 
 /// Quick Communication sheet: contact a coach with optional template, Send Email/Text, and link to Manage Templates.
@@ -5,8 +6,14 @@ struct QuickCommunicationView: View {
   let context: QuickCommunicationContext
 
   @State private var viewModel: QuickCommunicationViewModel
+  @State private var activeComposer: ActiveComposer?
+  @State private var showSuccessToast = false
+  @State private var showInfoToast = false
+  @State private var infoMessage: String?
   @Environment(\.openURL) private var openURL
   @Environment(\.dismiss) private var dismiss
+  @Environment(FamilyManager.self) private var familyManager
+  @Environment(AuthManager.self) private var authManager
 
   init(context: QuickCommunicationContext) {
     self.context = context
@@ -14,6 +21,11 @@ struct QuickCommunicationView: View {
       coach: context.coach,
       schoolName: context.schoolName
     ))
+  }
+
+  private enum ActiveComposer: Identifiable {
+    case mail, message
+    var id: Self { self }
   }
 
   var body: some View {
@@ -33,17 +45,22 @@ struct QuickCommunicationView: View {
             QuickCommBodyPreviewSection(filledBody: viewModel.filledBody)
           }
           QuickCommActionsSection(
-            mailtoURL: viewModel.mailtoURL(),
-            smsURL: viewModel.smsURL(),
+            showEmail: viewModel.mailtoURL() != nil,
+            showText: viewModel.smsURL() != nil,
             coachEmail: context.coach.email ?? "",
-            onOpenURL: { openURL($0) },
-            onDismiss: { dismiss() }
+            onSendEmail: handleSendEmail,
+            onSendText: handleSendText
           )
         }
         .padding()
       }
       .navigationTitle("Quick Communication")
       .navigationBarTitleDisplayMode(.inline)
+      .sheet(item: $activeComposer) { composer in
+        composerSheet(for: composer)
+      }
+      .toast(isShowing: $showSuccessToast, message: $viewModel.successMessage, type: .success, duration: 3.0)
+      .toast(isShowing: $showInfoToast, message: $infoMessage, type: .info, duration: 3.0)
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Done") { dismiss() }
@@ -60,8 +77,78 @@ struct QuickCommunicationView: View {
           CommunicationTemplatesView()
         }
       }
-      .task { await viewModel.loadTemplates() }
+      .task {
+        viewModel.configureContext(
+          loggedBy: authManager.user?.id,
+          familyUnitId: familyManager.currentMember?.familyUnitId
+        )
+        await viewModel.loadTemplates()
+      }
       .accessibilityIdentifier("quickCommunicationView")
+    }
+  }
+
+  // MARK: - Send handling
+
+  /// Present the in-app mail composer when the device can send mail; otherwise fall back to the
+  /// `mailto:` hand-off and log NOTHING (an external hand-off can't confirm the send).
+  private func handleSendEmail() {
+    if MFMailComposeViewController.canSendMail() {
+      activeComposer = .mail
+    } else if let url = viewModel.mailtoURL() {
+      openURL(url)
+      infoMessage = String(localized: "Log it from Interactions once sent.")
+      showInfoToast = true
+    }
+  }
+
+  /// Present the in-app message composer when the device can send texts; otherwise fall back to the
+  /// `sms:` hand-off and log NOTHING.
+  private func handleSendText() {
+    if MFMessageComposeViewController.canSendText() {
+      activeComposer = .message
+    } else if let url = viewModel.smsURL() {
+      openURL(url)
+      infoMessage = String(localized: "Log it from Interactions once sent.")
+      showInfoToast = true
+    }
+  }
+
+  @ViewBuilder
+  private func composerSheet(for composer: ActiveComposer) -> some View {
+    switch composer {
+    case .mail:
+      MailComposeView(
+        recipients: [context.coach.email].compactMap { $0 },
+        subject: viewModel.selectedTemplate?.name,
+        body: viewModel.filledBody,
+        onResult: { result, _ in handleMailResult(result) }
+      )
+      .ignoresSafeArea()
+    case .message:
+      MessageComposeView(
+        recipients: [context.coach.phone].compactMap { $0 },
+        body: viewModel.filledBody,
+        onResult: { handleMessageResult($0) }
+      )
+      .ignoresSafeArea()
+    }
+  }
+
+  /// Log ONLY on a confirmed `.sent`. `.cancelled`/`.saved`/`.failed` log nothing.
+  private func handleMailResult(_ result: MFMailComposeResult) {
+    guard result == .sent else { return }
+    Task {
+      await viewModel.logSend(.email)
+      if viewModel.didLogSend { showSuccessToast = true }
+    }
+  }
+
+  private func handleMessageResult(_ result: MessageComposeResult) {
+    guard result == .sent else { return }
+    Task {
+      await viewModel.logSend(.text)
+      if viewModel.didLogSend { showSuccessToast = true }
     }
   }
 }
@@ -196,19 +283,16 @@ private struct QuickCommBodyPreviewSection: View {
 }
 
 private struct QuickCommActionsSection: View {
-  let mailtoURL: URL?
-  let smsURL: URL?
+  let showEmail: Bool
+  let showText: Bool
   let coachEmail: String
-  let onOpenURL: (URL) -> Void
-  let onDismiss: () -> Void
+  let onSendEmail: () -> Void
+  let onSendText: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      if let mailto = mailtoURL {
-        Button {
-          onOpenURL(mailto)
-          onDismiss()
-        } label: {
+      if showEmail {
+        Button(action: onSendEmail) {
           Label("Send Email", systemImage: "envelope.fill")
             .font(.body.weight(.medium))
             .frame(maxWidth: .infinity)
@@ -216,14 +300,11 @@ private struct QuickCommActionsSection: View {
         }
         .buttonStyle(.borderedProminent)
         .accessibilityLabel(String(localized: "Send email to \(coachEmail)"))
-        .accessibilityHint("Opens Mail with recipient and optional message body")
+        .accessibilityHint("Opens Mail to compose; the message is logged only when sent")
       }
 
-      if let sms = smsURL {
-        Button {
-          onOpenURL(sms)
-          onDismiss()
-        } label: {
+      if showText {
+        Button(action: onSendText) {
           Label("Send Text", systemImage: "message.fill")
             .font(.body.weight(.medium))
             .frame(maxWidth: .infinity)
@@ -231,7 +312,7 @@ private struct QuickCommActionsSection: View {
         }
         .buttonStyle(.bordered)
         .accessibilityLabel(String(localized: "Send text to coach"))
-        .accessibilityHint("Opens Messages with optional message body")
+        .accessibilityHint("Opens Messages to compose; the message is logged only when sent")
       }
     }
   }
@@ -258,4 +339,6 @@ private struct QuickCommActionsSection: View {
       schoolName: "The College of Wooster"
     )
   )
+  .environment(FamilyManager.shared)
+  .environment(AuthManager.shared)
 }

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Coaches/ViewModels/QuickCommunicationViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Coaches/ViewModels/QuickCommunicationViewModelTests.swift
@@ -165,6 +165,110 @@ final class QuickCommunicationViewModelTests: XCTestCase {
     XCTAssertNil(sut.smsURL())
   }
 
+  // MARK: - logSend (log on confirmed send only)
+
+  /// The View calls `logSend` ONLY on a confirmed composer `.sent`; `.cancelled`/`.saved`/`.failed`
+  /// and the no-account fallback never reach it (view-level `guard result == .sent`). These tests
+  /// verify the ViewModel side: a confirmed send logs exactly one outbound interaction + stamps the
+  /// coach, and a missing user/family context logs nothing.
+
+  func testLogSend_email_createsOneOutboundInteractionWithEmailType() async {
+    let interactions = MockInteractionsService()
+    let coaches = MockCoachesService()
+    coaches.stubbedUpdatedCoach = makeCoach()
+    let sut = makeLoggingSut(interactions: interactions, coaches: coaches)
+
+    await sut.logSend(.email)
+
+    XCTAssertEqual(interactions.createInteractionCallCount, 1)
+    XCTAssertEqual(interactions.lastCreatedInteractionRequest?.type, "email")
+    XCTAssertEqual(interactions.lastCreatedInteractionRequest?.direction, "outbound")
+    XCTAssertEqual(interactions.lastCreatedInteractionRequest?.coachId, "coach-1")
+    XCTAssertEqual(interactions.lastCreatedInteractionRequest?.loggedBy, "user-1")
+    XCTAssertEqual(interactions.lastCreatedInteractionRequest?.familyUnitId, "family-1")
+    XCTAssertTrue(sut.didLogSend)
+    XCTAssertEqual(sut.successMessage, "Logged email to Coach Jane Smith.")
+    XCTAssertNil(sut.errorMessage)
+  }
+
+  func testLogSend_text_createsInteractionWithTextType() async {
+    let interactions = MockInteractionsService()
+    let coaches = MockCoachesService()
+    coaches.stubbedUpdatedCoach = makeCoach()
+    let sut = makeLoggingSut(interactions: interactions, coaches: coaches)
+
+    await sut.logSend(.text)
+
+    XCTAssertEqual(interactions.createInteractionCallCount, 1)
+    XCTAssertEqual(interactions.lastCreatedInteractionRequest?.type, "text")
+    XCTAssertEqual(sut.successMessage, "Logged text to Coach Jane Smith.")
+  }
+
+  func testLogSend_stampsLastContactDateOnce() async {
+    let interactions = MockInteractionsService()
+    let coaches = MockCoachesService()
+    coaches.stubbedUpdatedCoach = makeCoach()
+    let sut = makeLoggingSut(interactions: interactions, coaches: coaches)
+
+    await sut.logSend(.email)
+
+    XCTAssertEqual(coaches.updateCoachCallCount, 1)
+    XCTAssertEqual(coaches.lastUpdateCoachId, "coach-1")
+    XCTAssertNotNil(coaches.lastUpdateCoachUpdates?.lastContactDate)
+    XCTAssertNil(coaches.lastUpdateCoachUpdates?.notes)
+    XCTAssertNil(coaches.lastUpdateCoachUpdates?.nextContactDate)
+  }
+
+  func testLogSend_missingContext_logsNothing() async {
+    let interactions = MockInteractionsService()
+    let coaches = MockCoachesService()
+    // No loggedBy / familyUnitId injected.
+    let sut = QuickCommunicationViewModel(
+      coach: makeCoach(),
+      schoolName: "Test University",
+      templatesService: mockService,
+      interactionsService: interactions,
+      coachesService: coaches
+    )
+
+    await sut.logSend(.email)
+
+    XCTAssertEqual(interactions.createInteractionCallCount, 0)
+    XCTAssertEqual(coaches.updateCoachCallCount, 0)
+    XCTAssertFalse(sut.didLogSend)
+    XCTAssertEqual(sut.errorMessage, "Message sent, but logging it failed.")
+  }
+
+  func testLogSend_createInteractionFails_setsErrorAndDoesNotConfirm() async {
+    let interactions = MockInteractionsService()
+    interactions.shouldSucceed = false
+    let coaches = MockCoachesService()
+    let sut = makeLoggingSut(interactions: interactions, coaches: coaches)
+
+    await sut.logSend(.email)
+
+    XCTAssertFalse(sut.didLogSend)
+    XCTAssertNil(sut.successMessage)
+    XCTAssertEqual(coaches.updateCoachCallCount, 0)
+    XCTAssertEqual(sut.errorMessage, "Message sent, but logging it failed.")
+  }
+
+  private func makeLoggingSut(
+    interactions: MockInteractionsService,
+    coaches: MockCoachesService
+  ) -> QuickCommunicationViewModel {
+    let sut = QuickCommunicationViewModel(
+      coach: makeCoach(),
+      schoolName: "Test University",
+      templatesService: mockService,
+      interactionsService: interactions,
+      coachesService: coaches,
+      loggedBy: "user-1",
+      familyUnitId: "family-1"
+    )
+    return sut
+  }
+
   // MARK: - Helpers
 
   private func makeCoach(email: String? = "coach@example.com", phone: String? = "555-123-4567") -> Coach {

--- a/planning/HANDOFF_CoachOutreach_SendConfirmation.md
+++ b/planning/HANDOFF_CoachOutreach_SendConfirmation.md
@@ -1,0 +1,65 @@
+# Handoff — Implement Coach Outreach "Log on Confirmed Send" (iOS)
+
+**Run this in a fresh Claude session inside `recruiting-compass-ios`.**
+Copy the prompt block below and paste it as your first message.
+
+Origin: ports web change `1df52a39`. iOS diverges intentionally — logs only on a confirmed `.sent` from an in-app composer (no optimistic log, no undo). Full rationale + task list in [`planning/iOS_SPEC_CoachOutreach_SendConfirmation.md`](./iOS_SPEC_CoachOutreach_SendConfirmation.md).
+
+---
+
+## Paste-me prompt
+
+```
+Implement the spec at planning/iOS_SPEC_CoachOutreach_SendConfirmation.md.
+
+Feature: when an athlete sends an email/text to a coach from the Quick Communication
+sheet, log an outbound interaction — but ONLY when the send is actually confirmed.
+Use MFMailComposeViewController / MFMessageComposeViewController (in-app composers that
+report .sent), NOT the current mailto:/sms: openURL hand-off. No optimistic log, no undo.
+
+Before writing code:
+1. Read the full spec end to end.
+2. Orient (60s): open QuickCommunicationView.swift (:207-235 send buttons),
+   QuickCommunicationViewModel.swift (mailtoURL/smsURL, filledBody),
+   InteractionsManaging.swift + InteractionsServiceImpl.swift (createInteraction),
+   InteractionCreateRequest.swift, AddInteractionViewModel.swift:216-274
+   (how a VM resolves loggedBy + familyUnitId — mirror it).
+3. Resolve the two spec unknowns FIRST and report findings before task 5:
+   - Does a DB trigger already set coaches.last_contact_date on interactions insert?
+     (Check supabase migrations / server behavior.) If yes, SKIP spec task 5.
+   - Confirm InteractionType raw values are exactly "email" and "text".
+
+Then implement tasks 1-6 in order. Use TDD: write the ViewModel logging tests (task 6)
+RED first — .sent logs once, .cancelled/.saved/.failed and the canSendMail()==false
+fallback log NOTHING — then implement to green. Mock InteractionsManaging.
+
+Guardrails:
+- Only touch files named in the spec + their tests. No scope creep.
+- The fallback path (no Mail/Messages account) must log nothing — do not reintroduce
+  the false-positive the whole change exists to remove.
+- Success toast copy: "Logged email to Coach {fullName}." / "Logged text to Coach {fullName}."
+
+Build gate before you call it done:
+- xcodebuild build clean (no new warnings/errors in touched files)
+- new unit tests green
+- run it: launch in simulator, open a coach, tap Send Email, confirm the composer
+  presents; on Simulator (no Mail account) confirm the fallback opens the mail URL and
+  logs nothing; describe what you'd expect on a real device (.sent → one logged
+  interaction visible in Interactions).
+
+Report: files changed, test results, build status, and the two unknowns' answers.
+Commit only when I say so.
+```
+
+---
+
+## Acceptance checklist (verify before merge)
+
+- [ ] Two unknowns resolved & reported (last_contact_date trigger; InteractionType raws)
+- [ ] `MailComposeView` + `MessageComposeView` wrappers added
+- [ ] `QuickCommunicationViewModel.logSend(_:)` logs on confirmed send only
+- [ ] Send buttons present in-app composer; `canSendMail()`/`canSendText()` fallback logs nothing
+- [ ] `last_contact_date` handled (trigger → skip; else `CoachUpdateRequest.lastContactDate` added)
+- [ ] Tests: `.sent` logs once; other results + fallback log nothing
+- [ ] `xcodebuild build` clean; unit tests green; ran in simulator
+- [ ] Scope limited to spec files

--- a/planning/iOS_SPEC_CoachOutreach_SendConfirmation.md
+++ b/planning/iOS_SPEC_CoachOutreach_SendConfirmation.md
@@ -1,0 +1,106 @@
+# iOS Spec — Coach Outreach: Log on Confirmed Send
+
+**Source of truth:** web change `1df52a39` (feat: optimistic send-log with one-tap undo).
+**iOS divergence (approved):** iOS uses an **in-app mail/message composer** (`MFMailComposeViewController` / `MFMessageComposeViewController`) that reports a real send result. So iOS does **not** copy the web's optimistic-log-then-undo. It logs the interaction **only when the composer returns `.sent`**. No undo, no toast action button, no false "sent" for composed-but-abandoned drafts.
+
+## Why iOS differs from web
+
+| | Web | iOS (this spec) |
+|---|---|---|
+| Hand-off | `mailto:`/`sms:` → external app, no callback | `MFMailComposeViewController` in-app, delegate reports `.sent`/`.cancelled`/`.saved`/`.failed` |
+| When logged | Optimistically on tap | Only on `.sent` |
+| Correction | Undo toast (8s) deletes the row | Not needed — never logs an unsent message |
+| `last_contact_date` | App writes it, undo restores prior | App writes it on confirmed send (no undo to restore) |
+
+Net: iOS gets a **strictly better** UX for free because the platform exposes the outcome web can't see.
+
+## Current iOS state (verified)
+
+- `QuickCommunicationView.swift:207-235` — "Send Email"/"Send Text" buttons call `onOpenURL(mailto/sms)` then `onDismiss()`. **No logging today.** Uses `mailto:`/`sms:` via `@Environment(\.openURL)` — MessageUI is **not** used anywhere in the app.
+- `QuickCommunicationViewModel.swift:88/100` — `mailtoURL()` / `smsURL()` builders; `filledBody` (template-substituted); `coach`, `schoolName` only. **No** `interactionsService`, user id, or family id injected.
+- `InteractionsManaging.swift:17` — `createInteraction(_ InteractionCreateRequest) async throws -> Interaction`; `:22` `deleteInteraction`. Impl `InteractionsServiceImpl.swift:132-148`.
+- `InteractionCreateRequest.swift` — fields: `schoolId?`, `coachId?`, `eventId?`, `type` (`InteractionType`), `direction` (`Direction`), `occurredAt: Date`, `subject?`, `content?`, `sentiment?`, `loggedBy`, `familyUnitId`. Already sanitizes subject/content.
+- `Toast.swift` / `ToastModifier.swift` — success/error/info/warning, auto-dismiss, **X-dismiss only, no action button**. Reused as-is (no extension needed).
+- `CoachUpdateRequest.swift` — has `nextContactDate`, **NO `lastContactDate`**. See task 5.
+- Reference for how a VM gets `loggedBy` + `familyUnitId`: `AddInteractionViewModel.swift:216-274` (`submitInteraction()` → `createInteraction`, then cache invalidation `:271-274`). **Mirror its context-resolution.**
+
+## Implementation tasks
+
+### 1. `MailComposeView` — new file
+`.../Features/Coaches/Components/MailComposeView.swift`
+
+`UIViewControllerRepresentable` wrapping `MFMailComposeViewController`.
+- Inputs: `recipients: [String]`, `subject: String?`, `body: String?`.
+- Output: `onResult: (MFMailComposeResult, Error?) -> Void`.
+- Coordinator conforms to `MFMailComposeViewControllerDelegate`; on `didFinishWith` → dismiss the controller, then call `onResult`.
+- **Guard:** caller must check `MFMailComposeViewController.canSendMail()` before presenting (no Mail account → composer can't send). See task 4 fallback.
+
+### 2. `MessageComposeView` — new file
+`.../Features/Coaches/Components/MessageComposeView.swift`
+
+Same pattern wrapping `MFMessageComposeViewController` (`MessageComposeResult`, `MFMessageComposeViewControllerDelegate`). Inputs `recipients: [String]`, `body: String?`. Guard with `MFMessageComposeViewController.canSendText()`.
+
+### 3. ViewModel — log on confirmed send
+`QuickCommunicationViewModel.swift`
+
+- Inject `interactionsService: any InteractionsManaging` (default `InteractionsServiceImpl()`), plus current-user id + `familyUnitId` resolution mirroring `AddInteractionViewModel`. Add `coachId` / `schoolId` from `coach`.
+- Add:
+  ```swift
+  enum SendChannel { case email, text }
+
+  func logSend(_ channel: SendChannel) async {
+    do {
+      let req = InteractionCreateRequest(
+        schoolId: coach.schoolId,
+        coachId: coach.id,
+        type: channel == .email ? .email : .text,   // verify InteractionType has .email/.text → raw "email"/"text"
+        direction: .outbound,
+        occurredAt: Date(),
+        subject: selectedTemplate?.name,             // QuickComm has no subject field; template name or nil
+        content: filledBody.isEmpty ? nil : filledBody,
+        sentiment: nil,
+        loggedBy: <currentUserId>,
+        familyUnitId: <familyUnitId>
+      )
+      _ = try await interactionsService.createInteraction(req)
+      await updateLastContactDate()                  // task 5
+      didLogSend = true                              // drive success toast on parent
+    } catch {
+      logger.error("Failed to log sent interaction: \(error.localizedDescription)")
+      errorMessage = "Message sent, but logging it failed."
+    }
+  }
+  ```
+- Do **not** log on `.cancelled` / `.saved` / `.failed`.
+
+### 4. Wire the composer into the send buttons
+`QuickCommunicationView.swift` (`QuickCommActionsSection`)
+
+Replace the `onOpenURL(mailto); onDismiss()` bodies:
+- **Email tap:** if `MFMailComposeViewController.canSendMail()` → present `MailComposeView` (recipients `[coach.email]`, subject = `selectedTemplate?.name`, body = `filledBody`). On result `.sent` → `await viewModel.logSend(.email)` then dismiss + success toast. Any other result → dismiss, no log.
+- **Fallback** (`canSendMail() == false`, e.g. Simulator / no Mail account): keep the existing `openURL(mailtoURL())` behavior and **do not log** (can't confirm). Show an info toast: *"Log it from Interactions once sent."* (Do **not** silently log — that reintroduces the false-positive the whole change avoids.)
+- **Text tap:** same shape with `MessageComposeView` + `canSendText()` fallback to `smsURL()`.
+
+Success toast copy (parity with web wording): **"Logged email to Coach {fullName}."** / **"Logged text to Coach {fullName}."** — type `.success`. Present on the parent (`CoachesListView` already shows toasts at `:73`) after the sheet dismisses, or inside the sheet before dismiss — implementer's choice; prefer parent so it survives dismissal.
+
+### 5. `last_contact_date` write (parity)
+Web sets `last_contact_date` on the coach after logging. iOS has **no** app-side path (`CoachUpdateRequest` lacks the field).
+- Add `lastContactDate: String?` → `CoachUpdateRequest` with `case lastContactDate = "last_contact_date"`.
+- `updateLastContactDate()` calls `CoachesManaging.updateCoach(coachId, CoachUpdateRequest(lastContactDate: ISO8601 now))`.
+- **First verify** whether a DB trigger already sets `last_contact_date` on `interactions` insert. If yes, skip task 5 entirely (logging suffices). If no, implement it. Do not double-write.
+
+### 6. Tests
+`.../TheRecruitingCompassTests/...` — mock `InteractionsManaging`:
+- `.sent` result → `createInteraction` called once with `type == "email"`, `direction == "outbound"`, `coachId == coach.id`.
+- `.cancelled` / `.saved` / `.failed` → `createInteraction` **not** called.
+- `canSendMail() == false` fallback path → `createInteraction` **not** called (log-nothing guarantee).
+- If task 5 implemented: `updateCoach` called with `lastContactDate` on `.sent` only.
+
+## Out of scope / notes
+- No undo, no Toast action-button extension (iOS never logs an unsent message, so nothing to undo).
+- No optimistic insert — the whole point of using MessageUI is to avoid it.
+- Fallback path (no Mail/Messages account) intentionally logs nothing; acceptable — it's the same fire-and-forget the app has today, minus the false "sent."
+- Verify `InteractionType` raw values are `"email"` / `"text"` to match the web `interactions.type` domain before shipping.
+
+## Build gate
+`xcodebuild build` clean + new unit tests green before merge. This spec is unverified against a compiler (authored from the web session) — treat compile errors as expected first-pass fixes, not design changes.


### PR DESCRIPTION
## Summary

Ports web change `1df52a39` to iOS, diverging intentionally. Web logs optimistically on a `mailto:`/`sms:` hand-off and offers an 8s undo because it can't see whether the message was actually sent. iOS uses in-app `MFMailComposeViewController` / `MFMessageComposeViewController`, which report a real `.sent` result, so it logs **only on confirmed send** — no optimistic log, no undo, no false "sent" for composed-but-abandoned drafts.

## Changes

- **`MailComposeView` / `MessageComposeView`** (new) — `UIViewControllerRepresentable` wrappers reporting the composer result.
- **`QuickCommunicationViewModel.logSend(_:)`** — creates one outbound interaction, stamps the coach's `last_contact_date`, guards on missing user/family context, invalidates the interactions list cache.
- **`QuickCommunicationView`** — send buttons present the in-app composer; `.sent` → `logSend` + success toast; `.cancelled`/`.saved`/`.failed` log nothing; no-account fallback opens the `mailto:`/`sms:` URL and logs nothing (info toast).
- **`CoachUpdateRequest`** — add `lastContactDate` (`"last_contact_date"`) with an all-nil-default init. No DB trigger sets it (plain column, `web baseline.sql:1021`); web writes it app-side (`useCommunication.ts:102`), so iOS must too.

## Two unknowns (resolved)

- **`last_contact_date` trigger?** No → app writes it (task 5 implemented).
- **`InteractionType` raws?** `"email"` / `"text"` ✓.

## Test plan

Unit (all green, build exit 0):
- `.email` send → 1 outbound interaction, correct type/direction/coachId/loggedBy/familyUnitId, `didLogSend`, toast copy
- `.text` send → type `"text"`
- stamps `last_contact_date` once
- missing user/family context → logs nothing, errorMessage set
- `createInteraction` failure → no confirm, no coach stamp, errorMessage

Not automated (view-boundary / device):
- `.cancelled`/`.saved`/`.failed` + no-account fallback log nothing — enforced by view `guard result == .sent` (`MFMailComposeResult` is UIKit, not unit-testable).
- Real-device `.sent` path → manual test (Simulator has no Mail account).

https://claude.ai/code/session_01AFmKmQxRdpfnKzLbsLRLjP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app email and text composition for coach outreach.
  * Added fallback to external mail and messaging apps when native composition is unavailable.
  * Added send confirmations, success messages, and error handling.
  * Confirmed messages are recorded as interactions and update the coach’s last-contact date.

* **Bug Fixes**
  * Prevented unsent or cancelled messages from being logged.

* **Documentation**
  * Added implementation guidance and acceptance criteria for outreach tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->