### PR TITLE
fix: make Settings rows navigable (type-erased NavigationPath)

### DIFF
--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Views/MoreMenuView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Views/MoreMenuView.swift
@@ -10,7 +10,7 @@
 import SwiftUI
 
 struct MoreMenuView: View {
-  @State private var path: [MorePath] = []
+  @State private var path = NavigationPath()
   @Binding var externalPath: [MorePath]
   var notificationsViewModel: NotificationsListViewModel
 
@@ -30,7 +30,8 @@ struct MoreMenuView: View {
     }
     .onChange(of: externalPath) { _, newPath in
       guard !newPath.isEmpty else { return }
-      path = newPath
+      path = NavigationPath()
+      newPath.forEach { path.append($0) }
       externalPath = []
     }
   }
@@ -74,7 +75,7 @@ struct MoreMenuView: View {
     case .timeline:
       RecruitingTimelineView()
     case .events:
-      EventsListView(path: $path)
+      EventsListView()
     case .documents:
       DocumentsListView()
     case .offers:

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Events/Views/EventsListView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Events/Views/EventsListView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct EventsListView: View {
-  @Binding var path: [MorePath]
-
   @Environment(AuthManager.self) private var authManager
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @State private var viewModel = EventsListViewModel()

--- a/TheRecruitingCompass/TheRecruitingCompassUITests/Features/Settings/SettingsNavigationE2ETests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassUITests/Features/Settings/SettingsNavigationE2ETests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+/// Regression coverage for the Settings navigation bug: `MoreMenuView` used a
+/// homogeneous typed `NavigationStack(path: [MorePath])`, so every value-based
+/// `NavigationLink` inside `SettingsView` (which pushes `SettingsDestination`,
+/// not `MorePath`) was silently a no-op — every Settings row was a dead tap and
+/// the player profile could not be completed from the app. The fix switched the
+/// stack to a type-erased `NavigationPath`. These tests assert the rows push
+/// their destinations.
+final class SettingsNavigationE2ETests: XCTestCase {
+  private var app: XCUIApplication!
+  private var navigator: MainTabNavigator!
+
+  /// Settings rows that are value-based NavigationLinks (the ones the bug broke).
+  /// Excludes the two Legal rows, which are sheet-presenting Buttons.
+  private let navigationRowTitles = [
+    "Family Management",
+    "My Profile",
+    "Home Location",
+    "Player Details",
+    "School Preferences",
+    "Dashboard Customization",
+    "Notifications",
+    "Communication Templates",
+    "About & Feedback"
+  ]
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    app = XCUIApplication()
+    E2ETestEnvironment.configure(app)
+    app.launch()
+    navigator = MainTabNavigator(app: app)
+  }
+
+  override func tearDownWithError() throws {
+    app = nil
+    navigator = nil
+  }
+
+  @MainActor
+  private func loginAndOpenSettings() throws {
+    app.loginAsParent(email: "test@example.com", password: "TestPassword1")
+    guard app.waitForLogin(timeout: 10) else {
+      throw XCTSkip("Login failed - Supabase may not be configured")
+    }
+    guard navigator.goToMoreSection("Settings") else {
+      throw XCTSkip("Settings screen not reachable - navigation may not be wired")
+    }
+  }
+
+  /// Row labels carry a `"Title: description"` (and sometimes a badge) suffix, so
+  /// match on prefix. Scrolls the list until the row is hittable.
+  @MainActor
+  private func settingsRow(_ title: String) -> XCUIElement {
+    let row = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", title)).firstMatch
+    var attempts = 0
+    while !row.isHittable && attempts < 6 {
+      app.swipeUp()
+      attempts += 1
+    }
+    return row
+  }
+
+  @MainActor
+  private func popToSettings() {
+    let back = app.navigationBars.buttons["Settings"]
+    if back.exists {
+      back.tap()
+    }
+    XCTAssertTrue(
+      app.navigationBars["Settings"].waitForExistence(timeout: 5),
+      "Should return to the Settings list"
+    )
+  }
+
+  /// Core of the bug report: My Profile → the profile screen must open.
+  @MainActor
+  func testSettings_myProfile_opensProfileScreen() throws {
+    try loginAndOpenSettings()
+    add(app.takeScreenshot(name: "01-settings-list"))
+
+    settingsRow("My Profile").tap()
+
+    XCTAssertTrue(
+      app.navigationBars["My Profile"].waitForExistence(timeout: 10),
+      "Tapping My Profile should push the profile screen"
+    )
+    add(app.takeScreenshot(name: "02-my-profile-open"))
+  }
+
+  /// Player profile completion — the flow the user could not reach.
+  /// The row is titled "Player Details"; the pushed screen's nav bar is "Player Profile".
+  @MainActor
+  func testSettings_playerDetails_opensPlayerProfileScreen() throws {
+    try loginAndOpenSettings()
+
+    settingsRow("Player Details").tap()
+
+    XCTAssertTrue(
+      app.navigationBars["Player Profile"].waitForExistence(timeout: 10),
+      "Tapping Player Details should push the player profile editor"
+    )
+    add(app.takeScreenshot(name: "player-profile-open"))
+  }
+
+  /// Regression guard for the typed-stack bug: every NavigationLink row must
+  /// push *something* (a back button to Settings appears), not dead-tap.
+  @MainActor
+  func testSettings_allNavigationRows_pushDestination() throws {
+    try loginAndOpenSettings()
+
+    for title in navigationRowTitles {
+      let row = settingsRow(title)
+      XCTAssertTrue(row.exists, "Settings row '\(title)' should exist")
+      row.tap()
+
+      XCTAssertTrue(
+        app.navigationBars.buttons["Settings"].waitForExistence(timeout: 10),
+        "Tapping '\(title)' should push a destination (dead tap regression)"
+      )
+      popToSettings()
+    }
+  }
+}


### PR DESCRIPTION
## Problem

In the app, **More → Settings**, tapping any row did nothing — every option was a dead tap. As a result the **player profile could not be completed from iOS**.

## Root cause

`MoreMenuView` created a homogeneous, typed `NavigationStack(path: [MorePath])`. A typed-array navigation stack only pushes value-based `NavigationLink(value:)`s whose value type matches its element type. Every `SettingsView` row pushes `SettingsDestination` (≠ `MorePath`), so all links were silently no-ops — no crash, no log, just dead taps. The same latent bug affected `ProfileView`'s `ProfileDestination` links (the athlete-profile flow).

Only the two Legal rows worked, because they present sheets rather than navigating.

## Fix

- `MoreMenuView.swift`: `[MorePath]` → type-erased `NavigationPath`, so links of **any** `Hashable` type push correctly. Deep-link input (still `[MorePath]` from `MainTabView`) is appended element-by-element instead of assigned.
- `EventsListView.swift`: removed the dead `@Binding var path: [MorePath]` param (declared, never used) and its call-site argument.

One root change fixes all 9 Settings rows, the player-profile completion flow, and the same latent issue for any future value-based link under the More tab.

## Tests

New `SettingsNavigationE2ETests`:
- `testSettings_myProfile_opensProfileScreen` — the reported symptom
- `testSettings_playerDetails_opensPlayerProfileScreen` — player-profile completion flow
- `testSettings_allNavigationRows_pushDestination` — loops all 9 NavigationLink rows, asserts each pushes (regression guard for the typed-stack dead-tap bug)

Uses existing conventions (`E2ETestEnvironment`, `MainTabNavigator.goToMoreSection`, `loginAsParent`/`waitForLogin`, `XCTSkip` when Supabase absent). Supabase-gated — runs green against a local stack.

## Verification

- `xcodebuild build` — clean (exit 0)
- `xcodebuild build-for-testing` — clean (exit 0)
- Manually confirmed in iPhone 17 simulator: Settings taps now navigate.

https://claude.ai/code/session_01AFmKmQxRdpfnKzLbsLRLjP