### PR TITLE
Family-shared player profile — parent views & edits the athlete's data

### DIFF
--- a/.claude/skills/doc-cleanup/SKILL.md
+++ b/.claude/skills/doc-cleanup/SKILL.md
@@ -98,9 +98,32 @@ Log your classification and reasoning briefly for each file.
 | filename.md | domain | one-line summary |
 ```
 
-Then commit everything:
+Then commit **only the docs this run touched**. NEVER use `git add -A` / `git add .` — a blanket stage sweeps in unrelated working changes: in-progress feature code, build-generated files, and secrets. Specifically, `SupabaseConfig.generated.swift` is regenerated with the **real Supabase key on every build** and must never be committed.
+
+**1. Stage only doc paths this run deleted or wrote** — the two output files plus the exact manifest paths processed in passes 1–3 (each scoped with an explicit `--` pathspec, never a bare `git add`):
 
 ```bash
-git add -A
+git add -- docs/history/ COMPLETED_WORK.md
+# Plus each file this run deleted/compressed, by exact path:
+git add -- "<path from manifest.autoDelete / compress / review that this run touched>"
+# ...repeat one -- pathspec per touched file (records deletions too)
+```
+
+**2. Safety gate — abort if anything out of scope is staged.** Doc cleanup only ever touches `.md` files. If any non-`.md` file (or the generated Supabase config) is staged, unstage and STOP without committing:
+
+```bash
+staged=$(git diff --cached --name-only)
+offenders=$(echo "$staged" | grep -vE '\.md$')
+if [ -n "$offenders" ] || echo "$staged" | grep -q 'SupabaseConfig.generated.swift'; then
+  echo "ABORT: doc-cleanup must not commit non-doc files (code/config/secrets):"
+  echo "$offenders"
+  git reset -q
+  exit 1
+fi
+```
+
+**3. Commit** only after the gate passes:
+
+```bash
 git commit -m "chore: doc cleanup run YYYY-MM-DD"
 ```

--- a/COMPLETED_WORK.md
+++ b/COMPLETED_WORK.md
@@ -12,3 +12,25 @@
 - Compressed (Pass 3): 28 files → `docs/history/sessions.md`, `docs/history/infrastructure.md`, `docs/history/accessibility.md`, `docs/history/testing.md`
 - Deleted (Pass 3): 86 files (stale one-offs: preferences summaries, accessibility audits, completed implementation plans, old architecture reviews, session quick-refs)
 - Kept: 23 files (active specs, plans, guides, design system docs, App Store checklist)
+
+## Doc Cleanup Run — 2026-08-09
+- Deleted: 0 files
+- Compressed: 0 files
+- Kept: 13 files (active/future-looking)
+- No-op run: the 21 completed-work plans the scanner re-flagged were already deleted and folded into `docs/history/*.md` by the same-day commit `2512c39`. Only living references and open-work plans remain.
+
+| Doc | Domain | Summary |
+|-----|--------|---------|
+| planning/2026-03-15-swiftui-modernization.md | ios | Kept — SwiftUI refactor with open tasks (searchable, Swift Regex, .formatted()). |
+| planning/2026-03-17-notifications-system.md | infrastructure | Kept — partially-implemented notifications system, iOS items remaining. |
+| planning/2026-05-27-e2e-full-suite-green.md | e2e | Kept — phases 3–6 (green suite, CI, coverage gate, flake hardening) still open. |
+| planning/SPEC_notifications_system.md | infrastructure | Kept — active spec for partially-built notification system. |
+| docs/CODE_PATTERNS.md | general | Kept — living MVVM/pattern reference. |
+| docs/CONFIGURATION.md | infrastructure | Kept — living config/deployment reference. |
+| docs/E2E_TESTING.md | e2e | Kept — active E2E runbook. |
+| docs/TROUBLESHOOTING.md | general | Kept — living troubleshooting reference. |
+| docs/cron-schedules.md | infrastructure | Kept — pg_cron job reference. |
+| docs/design/colors.md | ui | Kept — design-system reference (BadgeColor roles). |
+| docs/design/components.md | ui | Kept — design-system reference (BadgeView). |
+| docs/design/states.md | ui | Kept — design-system reference (state→color mapping). |
+| docs/design/tokens.md | ui | Kept — design-system reference (brand palette tokens). |

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Components/ActionItemCard.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Components/ActionItemCard.swift
@@ -45,6 +45,11 @@ struct ActionItemCard: View {
             .fontWeight(.medium)
             .foregroundStyle(Color.primary)
             .lineLimit(3)
+
+          Button(String(localized: "Learn More")) { showHelp = true }
+            .font(.subheadline)
+            .foregroundStyle(Color.accentBlue)
+            .accessibilityHint("Shows detailed guidance for this suggestion")
         }
 
         Spacer()
@@ -72,10 +77,12 @@ struct ActionItemCard: View {
 
   @ViewBuilder
   private var actionRow: some View {
-    HStack(spacing: 16) {
+    HStack(spacing: 12) {
       if let label = cta.label {
         Button(label) { presentCTA() }
           .font(.subheadline.weight(.semibold))
+          .lineLimit(1)
+          .fixedSize(horizontal: true, vertical: false)
           .padding(.horizontal, 14)
           .padding(.vertical, 8)
           .background(suggestion.urgency.color)
@@ -84,35 +91,46 @@ struct ActionItemCard: View {
           .accessibilityHint("Opens the screen to complete this action")
       }
 
-      Button(String(localized: "Learn More")) { showHelp = true }
-        .font(.subheadline)
-        .foregroundStyle(Color.accentBlue)
-        .accessibilityHint("Shows detailed guidance for this suggestion")
+      Spacer(minLength: 8)
 
-      Spacer()
-
-      Button(action: onComplete) {
-        Image(systemName: "checkmark.circle.fill")
-          .foregroundStyle(Color.accentBlue)
-          .font(.title3)
-          .frame(minWidth: 44, minHeight: 44)
-          .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
+      iconLabelButton(
+        systemName: "checkmark.circle.fill",
+        title: String(localized: "Done"),
+        tint: Color.accentBlue,
+        action: onComplete
+      )
       .accessibilityLabel(String(localized: "Complete suggestion"))
       .accessibilityHint("Mark this suggestion as done")
 
-      Button(action: onDismiss) {
-        Image(systemName: "xmark.circle.fill")
-          .foregroundStyle(Color.gray)
-          .font(.title3)
-          .frame(minWidth: 44, minHeight: 44)
-          .contentShape(Rectangle())
-      }
-      .buttonStyle(.plain)
+      iconLabelButton(
+        systemName: "xmark.circle.fill",
+        title: String(localized: "Dismiss"),
+        tint: Color.gray,
+        action: onDismiss
+      )
       .accessibilityLabel(String(localized: "Dismiss suggestion"))
       .accessibilityHint("Hide this suggestion without completing it")
     }
+  }
+
+  private func iconLabelButton(
+    systemName: String,
+    title: String,
+    tint: Color,
+    action: @escaping () -> Void
+  ) -> some View {
+    Button(action: action) {
+      VStack(spacing: 2) {
+        Image(systemName: systemName)
+          .font(.title3)
+        Text(title)
+          .font(.caption2)
+      }
+      .foregroundStyle(tint)
+      .frame(minWidth: 52, minHeight: 44)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
   }
 
   private func presentCTA() {

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Views/DashboardView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Views/DashboardView.swift
@@ -108,6 +108,7 @@ struct DashboardView: View {
         }
       }
       .navigationTitle("Dashboard")
+      .navigationBarTitleDisplayMode(.inline)
       .sheet(isPresented: $showParentWizard) {
         ParentOnboardingWizardView(
           viewModel: ParentOnboardingWizardViewModel(),

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/PreferencePreviewMock.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/PreferencePreviewMock.swift
@@ -20,11 +20,11 @@ final class PreferencePreviewMock<T: Codable>: PreferenceManaging {
     self.defaultValue = defaultValue
   }
 
-  func fetchPreferences<U: Codable>(category: PreferenceCategory) async throws -> U? {
+  func fetchPreferences<U: Codable>(category: PreferenceCategory, userId: String?) async throws -> U? {
     return defaultValue as? U
   }
 
-  func savePreferences<U: Codable>(category: PreferenceCategory, data: U) async throws -> U {
+  func savePreferences<U: Codable>(category: PreferenceCategory, userId: String?, data: U) async throws -> U {
     return data
   }
 

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Services/PreferenceManaging.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Services/PreferenceManaging.swift
@@ -1,14 +1,30 @@
 import Foundation
 
 protocol PreferenceManaging: Sendable {
-  /// Fetch preferences for a specific category
-  /// Returns nil if no preferences exist for the category
-  func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T?
+  /// Fetch preferences for a category.
+  /// - Parameter userId: whose preferences to read. `nil` = the current user. A non-nil value
+  ///   targets a family member (e.g. a parent reading the athlete's player-owned prefs); the DB
+  ///   RLS policies decide whether the read is permitted.
+  /// Returns nil if no preferences exist for the category.
+  func fetchPreferences<T: Codable>(category: PreferenceCategory, userId: String?) async throws -> T?
 
-  /// Save preferences for a specific category
-  /// Creates new entry if none exists, updates if it does
-  func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T
+  /// Save preferences for a category.
+  /// - Parameter userId: whose row to write. `nil` = the current user. A non-nil value targets a
+  ///   family member's row (RLS-gated). Creates a new row if none exists, updates otherwise.
+  func savePreferences<T: Codable>(category: PreferenceCategory, userId: String?, data: T) async throws -> T
 
-  /// Delete preferences for a specific category
+  /// Delete preferences for a specific category (current user only)
   func deletePreferences(category: PreferenceCategory) async throws
+}
+
+extension PreferenceManaging {
+  /// Convenience: read the current user's own preferences.
+  func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T? {
+    try await fetchPreferences(category: category, userId: nil)
+  }
+
+  /// Convenience: save the current user's own preferences.
+  func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T {
+    try await savePreferences(category: category, userId: nil, data: data)
+  }
 }

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Services/PreferenceServiceImpl.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Services/PreferenceServiceImpl.swift
@@ -137,11 +137,11 @@ final class PreferenceServiceImpl: PreferenceManaging, Sendable {
     self.supabaseManager = supabaseManager
   }
 
-  func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T? {
+  func fetchPreferences<T: Codable>(category: PreferenceCategory, userId requestedUserId: String?) async throws -> T? {
     logger.debug("Fetching preferences for category: \(category.rawValue)")
 
     do {
-      let userId = try await getCurrentUserId()
+      let userId = try await resolveUserId(requestedUserId)
 
       let rows: [PreferenceResponse] = try await supabaseManager.client
         .from("user_preferences")
@@ -199,11 +199,11 @@ final class PreferenceServiceImpl: PreferenceManaging, Sendable {
     return try? JSONSerialization.data(withJSONObject: dict)
   }
 
-  func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T {
+  func savePreferences<T: Codable>(category: PreferenceCategory, userId requestedUserId: String?, data: T) async throws -> T {
     logger.debug("Saving preferences for category: \(category.rawValue)")
 
     do {
-      let userId = try await getCurrentUserId()
+      let userId = try await resolveUserId(requestedUserId)
 
       // Encode data to JSON dictionary
       let jsonData = try JSONEncoder().encode(data)
@@ -278,6 +278,12 @@ final class PreferenceServiceImpl: PreferenceManaging, Sendable {
   }
 
   // MARK: - Private Helpers
+
+  /// Resolves whose preferences to operate on: an explicit target, else the current user.
+  private func resolveUserId(_ requestedUserId: String?) async throws -> String {
+    if let requestedUserId { return requestedUserId }
+    return try await getCurrentUserId()
+  }
 
   private func getCurrentUserId() async throws -> String {
     guard let session = try await supabaseManager.getCurrentSession() else {

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/HomeLocationViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/HomeLocationViewModel.swift
@@ -19,6 +19,8 @@ final class HomeLocationViewModel {
   var isRequestingLocation = false
 
   private let preferenceService: any PreferenceManaging
+  /// Whose location this VM reads/writes. `nil` = current user; a parent passes the athlete's id.
+  private let targetUserId: String?
   private let geocoder: CLGeocoder
   private let locationService: any CurrentLocationProviding
   @ObservationIgnored nonisolated(unsafe) private var pendingAutoSave: Task<Void, Never>?
@@ -26,10 +28,12 @@ final class HomeLocationViewModel {
 
   init(
     preferenceService: any PreferenceManaging,
+    targetUserId: String? = nil,
     geocoder: CLGeocoder = CLGeocoder(),
     locationService: (any CurrentLocationProviding)? = nil
   ) {
     self.preferenceService = preferenceService
+    self.targetUserId = targetUserId
     self.geocoder = geocoder
     self.locationService = locationService ?? CoreLocationService()
   }
@@ -48,7 +52,7 @@ final class HomeLocationViewModel {
     defer { isLoading = false }
 
     do {
-      if let savedLocation: HomeLocation = try await preferenceService.fetchPreferences(category: .location) {
+      if let savedLocation: HomeLocation = try await preferenceService.fetchPreferences(category: .location, userId: targetUserId) {
         location = savedLocation
         logger.info("Loaded existing home location")
       } else {
@@ -67,7 +71,7 @@ final class HomeLocationViewModel {
     errorMessage = nil
 
     do {
-      _ = try await preferenceService.savePreferences(category: .location, data: location)
+      _ = try await preferenceService.savePreferences(category: .location, userId: targetUserId, data: location)
       saveStatus = .saved
       hapticSuccessTrigger += 1
       logger.info("Home location saved")

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
@@ -14,7 +14,10 @@ final class PlayerDetailsViewModel {
     var isLoading = false
     var isUploadingPhoto = false
     var errorMessage: String?
+    /// Optimistic local preview of a just-picked image (before/while it uploads).
     var profileImage: UIImage?
+    /// Persisted, family-shared photo URL for the athlete (`users.profile_photo_url`).
+    var photoUrl: String?
     var isReadOnly = false
     var showDeletePhotoConfirmation = false
     var saveStatus: SaveStatus = .idle
@@ -27,14 +30,25 @@ final class PlayerDetailsViewModel {
     var successMessage: String? { saveStatus == .saved ? "Saved" : nil }
 
     private let preferenceService: any PreferenceManaging
-    private let userRole: UserRole
+    private let photoService: any ProfilePhotoManaging
+    /// Whose player profile this VM reads/writes. `nil` = the current user's own row.
+    /// A parent viewing the family athlete passes the athlete's user id so the whole
+    /// family reads and edits the single canonical player row (RLS-gated).
+    private let targetUserId: String?
     @ObservationIgnored nonisolated(unsafe) private var pendingAutoSave: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var pendingStatusReset: Task<Void, Never>?
 
-    init(preferenceService: any PreferenceManaging, userRole: UserRole) {
+    init(
+        preferenceService: any PreferenceManaging,
+        userRole: UserRole,
+        targetUserId: String? = nil,
+        photoService: any ProfilePhotoManaging = ProfilePhotoServiceImpl()
+    ) {
         self.preferenceService = preferenceService
-        self.userRole = userRole
-        self.isReadOnly = (userRole == .parent)
+        self.photoService = photoService
+        self.targetUserId = targetUserId
+        // Parents and players collaborate on the same player profile; everyone can edit.
+        self.isReadOnly = false
     }
 
     nonisolated deinit {
@@ -76,7 +90,7 @@ final class PlayerDetailsViewModel {
         errorMessage = nil
         defer { isLoading = false }
         do {
-            if let savedDetails: PlayerDetails = try await preferenceService.fetchPreferences(category: .player) {
+            if let savedDetails: PlayerDetails = try await preferenceService.fetchPreferences(category: .player, userId: targetUserId) {
                 details = savedDetails
                 logger.info("Loaded existing player details")
             } else {
@@ -88,6 +102,17 @@ final class PlayerDetailsViewModel {
             logger.error("Failed to load details: \(error.localizedDescription)")
             errorMessage = String(localized: "Failed to load player details. Please try again.")
         }
+        await loadPhoto()
+    }
+
+    /// Loads the athlete's persisted, family-shared profile photo URL for display.
+    func loadPhoto() async {
+        guard let userId = targetUserId else { return }
+        do {
+            photoUrl = try await photoService.currentPhotoURL(userId: userId)
+        } catch {
+            logger.error("Failed to load profile photo: \(error.localizedDescription)")
+        }
     }
 
     func saveDetails() async {
@@ -96,7 +121,7 @@ final class PlayerDetailsViewModel {
         saveStatus = .saving
         normalizePositions()
         do {
-            _ = try await preferenceService.savePreferences(category: .player, data: details)
+            _ = try await preferenceService.savePreferences(category: .player, userId: targetUserId, data: details)
             saveStatus = .saved
             hapticSuccessTrigger += 1
             logger.info("Player details saved")
@@ -122,37 +147,34 @@ final class PlayerDetailsViewModel {
     // MARK: - Photo Upload
 
     func uploadProfilePhoto(_ image: UIImage) async {
-        guard !isReadOnly else { return }
+        guard !isReadOnly, let userId = targetUserId else { return }
         logger.debug("Uploading profile photo")
         isUploadingPhoto = true
         errorMessage = nil
         defer { isUploadingPhoto = false }
         do {
-            // Downsample + encode off the main actor: a full-resolution photo-picker
-            // image can take 300-800ms to encode, which would otherwise freeze the UI.
-            let compressedData = await Task.detached(priority: .userInitiated) {
-                ImageCompression.downsampledJPEGData(from: image, maxBytes: 5_000_000)
-            }.value
-            guard let compressedData else {
-                throw PhotoError.compressionFailed
-            }
-            guard compressedData.count <= 5_000_000 else {
-                throw PhotoError.fileTooLarge
-            }
-            profileImage = image
-            markChanged()
+            profileImage = image  // optimistic preview while the upload runs
+            let url = try await photoService.upload(image: image, userId: userId)
+            photoUrl = url
             logger.info("Profile photo uploaded successfully")
         } catch {
+            profileImage = nil
             logger.error("Failed to upload photo: \(error.localizedDescription)")
             errorMessage = String(localized: "Failed to upload photo. Please try again.")
         }
     }
 
     func deleteProfilePhoto() async {
-        guard !isReadOnly else { return }
-        profileImage = nil
-        markChanged()
-        logger.info("Profile photo deleted")
+        guard !isReadOnly, let userId = targetUserId else { return }
+        do {
+            try await photoService.delete(userId: userId, currentPhotoURL: photoUrl ?? "")
+            profileImage = nil
+            photoUrl = nil
+            logger.info("Profile photo deleted")
+        } catch {
+            logger.error("Failed to delete photo: \(error.localizedDescription)")
+            errorMessage = String(localized: "Failed to remove photo. Please try again.")
+        }
     }
 
     // MARK: - Field Updates

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/SchoolPreferencesViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/SchoolPreferencesViewModel.swift
@@ -19,11 +19,14 @@ final class SchoolPreferencesViewModel {
   var pendingTemplate: String?
 
   private let preferenceService: any PreferenceManaging
+  /// Whose school prefs this VM reads/writes. `nil` = current user; a parent passes the athlete's id.
+  private let targetUserId: String?
   @ObservationIgnored nonisolated(unsafe) private var pendingAutoSave: Task<Void, Never>?
   @ObservationIgnored nonisolated(unsafe) private var pendingStatusReset: Task<Void, Never>?
 
-  init(preferenceService: any PreferenceManaging) {
+  init(preferenceService: any PreferenceManaging, targetUserId: String? = nil) {
     self.preferenceService = preferenceService
+    self.targetUserId = targetUserId
   }
 
   nonisolated deinit {
@@ -40,7 +43,7 @@ final class SchoolPreferencesViewModel {
     defer { isLoading = false }
 
     do {
-      if let savedPreferences: SchoolPreferences = try await preferenceService.fetchPreferences(category: .school) {
+      if let savedPreferences: SchoolPreferences = try await preferenceService.fetchPreferences(category: .school, userId: targetUserId) {
         preferences = savedPreferences
         logger.info("Loaded existing school preferences")
       } else {
@@ -60,7 +63,7 @@ final class SchoolPreferencesViewModel {
     preferences.lastUpdated = Date.now.ISO8601Format()
 
     do {
-      _ = try await preferenceService.savePreferences(category: .school, data: preferences)
+      _ = try await preferenceService.savePreferences(category: .school, userId: targetUserId, data: preferences)
       saveStatus = .saved
       hapticSuccessTrigger += 1
       logger.info("School preferences saved")

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/HomeLocationView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/HomeLocationView.swift
@@ -162,10 +162,10 @@ struct HomeLocationView: View {
   final class PreviewMock: PreferenceManaging {
     let location: HomeLocation
     init(location: HomeLocation) { self.location = location }
-    func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T? {
+    func fetchPreferences<T: Codable>(category: PreferenceCategory, userId: String?) async throws -> T? {
       return location as? T
     }
-    func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T { data }
+    func savePreferences<T: Codable>(category: PreferenceCategory, userId: String?, data: T) async throws -> T { data }
     func deletePreferences(category: PreferenceCategory) async throws {}
   }
 

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/HomeLocationView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/HomeLocationView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 struct HomeLocationView: View {
   @State private var viewModel: HomeLocationViewModel
 
-  init(preferenceService: PreferenceManaging) {
-    _viewModel = State(initialValue: HomeLocationViewModel(preferenceService: preferenceService))
+  init(preferenceService: PreferenceManaging, targetUserId: String? = nil) {
+    _viewModel = State(initialValue: HomeLocationViewModel(
+      preferenceService: preferenceService, targetUserId: targetUserId))
   }
 
   var body: some View {

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/NotificationPreferencesView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/NotificationPreferencesView.swift
@@ -172,10 +172,10 @@ struct NotificationPreferencesView: View {
 #Preview {
   // Simple preview mock
   final class PreviewMock: PreferenceManaging {
-    func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T? {
+    func fetchPreferences<T: Codable>(category: PreferenceCategory, userId: String?) async throws -> T? {
       return NotificationSettings.default as? T
     }
-    func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T { data }
+    func savePreferences<T: Codable>(category: PreferenceCategory, userId: String?, data: T) async throws -> T { data }
     func deletePreferences(category: PreferenceCategory) async throws {}
   }
 

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/PlayerDetailsView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/PlayerDetailsView.swift
@@ -3,10 +3,11 @@ import SwiftUI
 struct PlayerDetailsView: View {
     @State private var viewModel: PlayerDetailsViewModel
 
-    init(preferenceService: any PreferenceManaging, userRole: UserRole) {
+    init(preferenceService: any PreferenceManaging, userRole: UserRole, targetUserId: String? = nil) {
         _viewModel = State(initialValue: PlayerDetailsViewModel(
             preferenceService: preferenceService,
-            userRole: userRole
+            userRole: userRole,
+            targetUserId: targetUserId
         ))
     }
 

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/SchoolPreferencesView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/SchoolPreferencesView.swift
@@ -4,8 +4,9 @@ struct SchoolPreferencesView: View {
   @State private var viewModel: SchoolPreferencesViewModel
   @Environment(\.editMode) private var editMode
 
-  init(preferenceService: PreferenceManaging) {
-    _viewModel = State(initialValue: SchoolPreferencesViewModel(preferenceService: preferenceService))
+  init(preferenceService: PreferenceManaging, targetUserId: String? = nil) {
+    _viewModel = State(initialValue: SchoolPreferencesViewModel(
+      preferenceService: preferenceService, targetUserId: targetUserId))
   }
 
   var body: some View {

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift
@@ -53,6 +53,18 @@ struct BasicsTab: View {
                     .scaledToFill()
                     .frame(width: 120, height: 120)
                     .clipShape(Circle())
+            } else if let urlString = viewModel.photoUrl, let url = URL(string: urlString) {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image.resizable().scaledToFill()
+                    default:
+                        Image(systemName: "person.crop.circle.fill")
+                            .resizable().scaledToFit().foregroundStyle(.tertiary)
+                    }
+                }
+                .frame(width: 120, height: 120)
+                .clipShape(Circle())
             } else {
                 Image(systemName: "person.crop.circle.fill")
                     .resizable()
@@ -67,7 +79,7 @@ struct BasicsTab: View {
             .accessibilityLabel(String(localized: "Choose profile photo"))
             .disabled(viewModel.isReadOnly)
 
-            if viewModel.profileImage != nil {
+            if viewModel.profileImage != nil || viewModel.photoUrl != nil {
                 Button(role: .destructive) {
                     viewModel.showDeletePhotoConfirmation = true
                 } label: {

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Profile/Services/ProfilePhotoService.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Profile/Services/ProfilePhotoService.swift
@@ -30,6 +30,8 @@ enum ProfilePhotoError: LocalizedError {
 protocol ProfilePhotoManaging: Sendable {
     func upload(image: UIImage, userId: String) async throws -> String
     func delete(userId: String, currentPhotoURL: String) async throws
+    /// The current profile photo URL for a user (self or a family athlete, RLS-gated).
+    func currentPhotoURL(userId: String) async throws -> String?
 }
 
 final class ProfilePhotoServiceImpl: ProfilePhotoManaging, Sendable {
@@ -63,11 +65,7 @@ final class ProfilePhotoServiceImpl: ProfilePhotoManaging, Sendable {
             .getPublicURL(path: path))?.absoluteString ?? ""
 
         do {
-            try await supabaseManager.client
-                .from("users")
-                .update(["profile_photo_url": publicURL])
-                .eq("id", value: userId)
-                .execute()
+            try await setProfilePhotoURL(userId: userId, url: .string(publicURL))
         } catch {
             logger.error("Failed to update profile_photo_url: \(error.localizedDescription)")
             throw ProfilePhotoError.updateRecordFailed(error)
@@ -91,11 +89,7 @@ final class ProfilePhotoServiceImpl: ProfilePhotoManaging, Sendable {
         }
 
         do {
-            try await supabaseManager.client
-                .from("users")
-                .update(["profile_photo_url": AnyJSON.null])
-                .eq("id", value: userId)
-                .execute()
+            try await setProfilePhotoURL(userId: userId, url: .null)
         } catch {
             logger.error("Failed to clear profile_photo_url: \(error.localizedDescription)")
             throw ProfilePhotoError.deleteFailed(error)
@@ -104,7 +98,27 @@ final class ProfilePhotoServiceImpl: ProfilePhotoManaging, Sendable {
         logger.info("Profile photo removed for user \(userId, privacy: .private)")
     }
 
+    func currentPhotoURL(userId: String) async throws -> String? {
+        struct Row: Decodable { let profile_photo_url: String? }
+        let row: Row = try await supabaseManager.client
+            .from("users")
+            .select("profile_photo_url")
+            .eq("id", value: userId)
+            .single()
+            .execute()
+            .value
+        return row.profile_photo_url
+    }
+
     // MARK: - Private helpers
+
+    /// Persists profile_photo_url via a SECURITY DEFINER RPC so a parent can set a family
+    /// athlete's photo (and a user their own). Column-scoped; RLS on `users` stays self-only.
+    private func setProfilePhotoURL(userId: String, url: AnyJSON) async throws {
+        try await supabaseManager.client
+            .rpc("set_athlete_profile_photo", params: ["athlete_id": AnyJSON.string(userId), "photo_url": url])
+            .execute()
+    }
 
     private func compress(_ image: UIImage) -> Data? {
         ImageCompression.downsampledJPEGData(from: image)

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Profile/Views/ProfileView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Profile/Views/ProfileView.swift
@@ -7,6 +7,7 @@ private enum ProfileDestination: Hashable {
 
 struct ProfileView: View {
     @Environment(AuthManager.self) private var authManager
+    @Environment(FamilyManager.self) private var familyManager
     @State private var viewModel = ProfileViewModel()
     @State private var selectedPhotoItem: PhotosPickerItem?
 
@@ -35,7 +36,11 @@ struct ProfileView: View {
         .navigationDestination(for: ProfileDestination.self) { destination in
             switch destination {
             case .playerDetails:
-                PlayerDetailsView(preferenceService: preferenceService, userRole: .player)
+                PlayerDetailsView(
+                    preferenceService: preferenceService,
+                    userRole: user?.role ?? .player,
+                    targetUserId: familyManager.selectedAthlete?.userId ?? authManager.user?.id
+                )
             }
         }
         .task {
@@ -579,5 +584,6 @@ private struct InitialsAvatar: View {
     NavigationStack {
         ProfileView()
             .environment(AuthManager.shared)
+            .environment(FamilyManager.shared)
     }
 }

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Schools/ViewModels/SchoolDetailViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Schools/ViewModels/SchoolDetailViewModel.swift
@@ -191,7 +191,7 @@ final class SchoolDetailViewModel {
   /// distance simply won't show.
   func loadHomeLocation() async {
     do {
-      if let location: HomeLocation = try await preferenceService.fetchPreferences(category: .location),
+      if let location: HomeLocation = try await preferenceService.fetchPreferences(category: .location, userId: familyManager.selectedAthlete?.userId),
          let lat = location.latitude,
          let lon = location.longitude {
         homeCoordinate = CLLocationCoordinate2D(latitude: lat, longitude: lon)

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Schools/ViewModels/SchoolsListViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Schools/ViewModels/SchoolsListViewModel.swift
@@ -192,7 +192,7 @@ final class SchoolsListViewModel {
 
       // Load home location from Settings (user_preferences).
       do {
-        if let location: HomeLocation = try await preferenceService.fetchPreferences(category: .location),
+        if let location: HomeLocation = try await preferenceService.fetchPreferences(category: .location, userId: familyManager.selectedAthlete?.userId),
            let lat = location.latitude, let lon = location.longitude {
           homeLocationFromPreferences = CLLocationCoordinate2D(latitude: lat, longitude: lon)
           logger.debug("Using home location from preferences")

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/Views/SettingsView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/Views/SettingsView.swift
@@ -228,7 +228,8 @@ struct SettingsView: View {
         case .playerDetails:
           PlayerDetailsView(
             preferenceService: preferenceService,
-            userRole: authManager.user?.role ?? .player
+            userRole: authManager.user?.role ?? .player,
+            targetUserId: familyManager.selectedAthlete?.userId ?? authManager.user?.id
           )
         case .schoolPreferences:
           SchoolPreferencesView(preferenceService: preferenceService)

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/Views/SettingsView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/Views/SettingsView.swift
@@ -224,7 +224,10 @@ struct SettingsView: View {
         case .profile:
           ProfileView(preferenceService: preferenceService)
         case .homeLocation:
-          HomeLocationView(preferenceService: preferenceService)
+          HomeLocationView(
+            preferenceService: preferenceService,
+            targetUserId: familyManager.selectedAthlete?.userId ?? authManager.user?.id
+          )
         case .playerDetails:
           PlayerDetailsView(
             preferenceService: preferenceService,
@@ -232,7 +235,10 @@ struct SettingsView: View {
             targetUserId: familyManager.selectedAthlete?.userId ?? authManager.user?.id
           )
         case .schoolPreferences:
-          SchoolPreferencesView(preferenceService: preferenceService)
+          SchoolPreferencesView(
+            preferenceService: preferenceService,
+            targetUserId: familyManager.selectedAthlete?.userId ?? authManager.user?.id
+          )
         case .dashboardCustomization:
           DashboardCustomizationView(preferenceService: preferenceService)
         case .notificationPreferences:

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/Views/SettingsView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/Views/SettingsView.swift
@@ -72,17 +72,8 @@ struct SettingsView: View {
           Text("Family")
         }
 
-        // Profile & Player Info Section
+        // Player Info Section
         Section {
-          NavigationLink(value: SettingsDestination.profile) {
-            SettingsRow(
-              icon: "person.circle.fill",
-              title: String(localized: "My Profile"),
-              description: String(localized: "Photo, name, email, password, and account settings"),
-              color: .blue
-            )
-          }
-
           NavigationLink(value: SettingsDestination.homeLocation) {
             SettingsRow(
               icon: "house.fill",
@@ -112,7 +103,7 @@ struct SettingsView: View {
             )
           }
         } header: {
-          Text("Profile & Player Info")
+          Text("Player Info")
         }
 
         // School Preferences Section
@@ -165,6 +156,20 @@ struct SettingsView: View {
           }
         } header: {
           Text("Communication & Social")
+        }
+
+        // User Settings Section
+        Section {
+          NavigationLink(value: SettingsDestination.profile) {
+            SettingsRow(
+              icon: "person.circle.fill",
+              title: String(localized: "User Settings"),
+              description: String(localized: "Photo, name, email, password, and account settings"),
+              color: .blue
+            )
+          }
+        } header: {
+          Text("User Settings")
         }
 
         // Legal Section

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Timeline/ViewModels/TimelineViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Timeline/ViewModels/TimelineViewModel.swift
@@ -83,7 +83,7 @@ final class TimelineViewModel {
     defer { isLoading = false }
 
     do {
-      let prefs: PlayerDetails? = try await preferenceService.fetchPreferences(category: .player)
+      let prefs: PlayerDetails? = try await preferenceService.fetchPreferences(category: .player, userId: currentAthleteId)
       let tasksByGradeResult = try await tasksService.fetchAllTasksWithStatus(athleteId: athleteId)
       graduationYear = prefs?.graduationYear
       tasksByGrade = tasksByGradeResult

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Mocks/MockPreferenceManager.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Mocks/MockPreferenceManager.swift
@@ -6,12 +6,12 @@ final class MockPreferenceManager: PreferenceManaging, @unchecked Sendable {
   var savePreferencesResult: Result<Any, Error>?
   var deletePreferencesCalled = false
 
-  var fetchPreferencesCalls: [PreferenceCategory] = []
-  var savePreferencesCalls: [(category: PreferenceCategory, data: Any)] = []
+  var fetchPreferencesCalls: [(category: PreferenceCategory, userId: String?)] = []
+  var savePreferencesCalls: [(category: PreferenceCategory, userId: String?, data: Any)] = []
   var deletePreferencesCalls: [PreferenceCategory] = []
 
-  func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T? {
-    fetchPreferencesCalls.append(category)
+  func fetchPreferences<T: Codable>(category: PreferenceCategory, userId: String?) async throws -> T? {
+    fetchPreferencesCalls.append((category: category, userId: userId))
 
     switch fetchPreferencesResult {
     case .success(let value):
@@ -21,8 +21,8 @@ final class MockPreferenceManager: PreferenceManaging, @unchecked Sendable {
     }
   }
 
-  func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T {
-    savePreferencesCalls.append((category: category, data: data))
+  func savePreferences<T: Codable>(category: PreferenceCategory, userId: String?, data: T) async throws -> T {
+    savePreferencesCalls.append((category: category, userId: userId, data: data))
 
     if let result = savePreferencesResult {
       switch result {

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Mocks/MockPreferenceManager.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Mocks/MockPreferenceManager.swift
@@ -27,7 +27,7 @@ final class MockPreferenceManager: PreferenceManaging, @unchecked Sendable {
     if let result = savePreferencesResult {
       switch result {
       case .success(let value):
-        return value as! T
+        return (value as? T) ?? data
       case .failure(let error):
         throw error
       }

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/NotificationPreferencesPushTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/NotificationPreferencesPushTests.swift
@@ -59,7 +59,7 @@ struct NotificationPreferencesPushTests {
 
 // Minimal mock for PreferenceManaging (already tested elsewhere)
 private final class MockPreferenceManaging: PreferenceManaging {
-    func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T? { nil }
-    func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T { data }
+    func fetchPreferences<T: Codable>(category: PreferenceCategory, userId: String?) async throws -> T? { nil }
+    func savePreferences<T: Codable>(category: PreferenceCategory, userId: String?, data: T) async throws -> T { data }
     func deletePreferences(category: PreferenceCategory) async throws {}
 }

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Services/PreferenceServiceTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Services/PreferenceServiceTests.swift
@@ -29,7 +29,7 @@ final class PreferenceServiceTests: XCTestCase {
     // Then
     XCTAssertEqual(result, expectedSettings)
     XCTAssertEqual(mockManager.fetchPreferencesCalls.count, 1)
-    XCTAssertEqual(mockManager.fetchPreferencesCalls.first, .notifications)
+    XCTAssertEqual(mockManager.fetchPreferencesCalls.first?.category, .notifications)
   }
 
   func testFetchPreferences_WhenNoPreferences_ReturnsNil() async throws {

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/ViewModels/PlayerDetailsViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/ViewModels/PlayerDetailsViewModelTests.swift
@@ -6,15 +6,18 @@ final class PlayerDetailsViewModelTests: XCTestCase {
   nonisolated deinit {}
   var viewModel: PlayerDetailsViewModel!
   var mockService: MockPreferenceManager!
+  var mockPhoto: MockProfilePhotoService!
 
   override func setUp() async throws {
     try await super.setUp()
     mockService = MockPreferenceManager()
+    mockPhoto = MockProfilePhotoService()
   }
 
   override func tearDown() {
     viewModel = nil
     mockService = nil
+    mockPhoto = nil
     super.tearDown()
   }
 
@@ -75,14 +78,15 @@ final class PlayerDetailsViewModelTests: XCTestCase {
     XCTAssertEqual(viewModel.saveStatus, .saved)
   }
 
-  // MARK: - Role-Based Access Tests
+  // MARK: - Family Collaboration Tests
+  // Parents and players collaborate on one shared player profile; everyone can edit.
 
-  func testInit_WhenParentRole_SetsReadOnly() {
+  func testInit_WhenParentRole_IsNotReadOnly() {
     // When
     viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .parent)
 
     // Then
-    XCTAssertTrue(viewModel.isReadOnly)
+    XCTAssertFalse(viewModel.isReadOnly)
   }
 
   func testInit_WhenPlayerRole_NotReadOnly() {
@@ -93,18 +97,22 @@ final class PlayerDetailsViewModelTests: XCTestCase {
     XCTAssertFalse(viewModel.isReadOnly)
   }
 
-  func testSaveDetails_WhenParentRole_DoesNotSave() async {
-    // Given
-    viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .parent)
+  func testSaveDetails_WhenParentRole_SavesToAthleteRow() async {
+    // Given a parent editing the athlete's profile
+    viewModel = PlayerDetailsViewModel(
+      preferenceService: mockService, userRole: .parent, targetUserId: "athlete-123")
+    mockService.savePreferencesResult = .success(viewModel.details)
 
     // When
     await viewModel.saveDetails()
 
-    // Then
-    XCTAssertEqual(mockService.savePreferencesCalls.count, 0)
+    // Then it saves, targeting the athlete's user id
+    XCTAssertEqual(mockService.savePreferencesCalls.count, 1)
+    XCTAssertEqual(mockService.savePreferencesCalls.first?.userId, "athlete-123")
+    XCTAssertEqual(mockService.savePreferencesCalls.first?.category, .player)
   }
 
-  func testMarkChanged_WhenParentRole_DoesNotMarkChanges() {
+  func testMarkChanged_WhenParentRole_MarksChanges() {
     // Given
     viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .parent)
 
@@ -112,48 +120,86 @@ final class PlayerDetailsViewModelTests: XCTestCase {
     viewModel.markChanged()
 
     // Then
-    XCTAssertFalse(viewModel.hasUnsavedChanges)
+    XCTAssertTrue(viewModel.hasUnsavedChanges)
+  }
+
+  func testLoadDetails_WithTargetUserId_FetchesAthleteRow() async {
+    // Given a parent viewing the athlete's profile
+    viewModel = PlayerDetailsViewModel(
+      preferenceService: mockService, userRole: .parent, targetUserId: "athlete-123",
+      photoService: mockPhoto)
+    mockService.fetchPreferencesResult = .success(nil)
+
+    // When
+    await viewModel.loadDetails()
+
+    // Then the fetch targets the athlete's user id
+    XCTAssertEqual(mockService.fetchPreferencesCalls.first?.userId, "athlete-123")
+    XCTAssertEqual(mockService.fetchPreferencesCalls.first?.category, .player)
+  }
+
+  func testLoadDetails_WithoutTargetUserId_FetchesOwnRow() async {
+    // Given a player viewing their own profile (no explicit target)
+    viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .player)
+    mockService.fetchPreferencesResult = .success(nil)
+
+    // When
+    await viewModel.loadDetails()
+
+    // Then the fetch uses nil (current user)
+    XCTAssertNil(mockService.fetchPreferencesCalls.first?.userId)
   }
 
   // MARK: - Photo Upload Tests
 
-  func testUploadProfilePhoto_WithValidImage_UploadsSuccessfully() async {
+  func testUploadProfilePhoto_WithValidImage_PersistsToTargetUser() async {
     // Given
-    viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .player)
+    viewModel = PlayerDetailsViewModel(
+      preferenceService: mockService, userRole: .player, targetUserId: "self-1",
+      photoService: mockPhoto)
+    mockPhoto.stubbedUploadURL = "https://example.com/new.jpg"
     let testImage = UIImage(systemName: "person.fill")!
 
     // When
     await viewModel.uploadProfilePhoto(testImage)
 
-    // Then
+    // Then it persists via the photo service, targeting the resolved user id
     XCTAssertNotNil(viewModel.profileImage)
-    XCTAssertTrue(viewModel.hasUnsavedChanges)
+    XCTAssertEqual(viewModel.photoUrl, "https://example.com/new.jpg")
+    XCTAssertEqual(mockPhoto.lastUploadUserId, "self-1")
     XCTAssertFalse(viewModel.isUploadingPhoto)
   }
 
   func testDeleteProfilePhoto_RemovesPhoto() async {
     // Given
-    viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .player)
+    viewModel = PlayerDetailsViewModel(
+      preferenceService: mockService, userRole: .player, targetUserId: "self-1",
+      photoService: mockPhoto)
     viewModel.profileImage = UIImage(systemName: "person.fill")
+    viewModel.photoUrl = "https://example.com/old.jpg"
 
     // When
     await viewModel.deleteProfilePhoto()
 
     // Then
     XCTAssertNil(viewModel.profileImage)
-    XCTAssertTrue(viewModel.hasUnsavedChanges)
+    XCTAssertNil(viewModel.photoUrl)
+    XCTAssertEqual(mockPhoto.lastDeleteUserId, "self-1")
   }
 
-  func testUploadProfilePhoto_WhenReadOnly_DoesNotUpload() async {
-    // Given
-    viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .parent)
+  func testUploadProfilePhoto_WhenParentRole_PersistsToAthlete() async {
+    // Given a parent editing the athlete's profile (parents can now edit)
+    viewModel = PlayerDetailsViewModel(
+      preferenceService: mockService, userRole: .parent, targetUserId: "athlete-123",
+      photoService: mockPhoto)
     let testImage = UIImage(systemName: "person.fill")!
 
     // When
     await viewModel.uploadProfilePhoto(testImage)
 
-    // Then
-    XCTAssertNil(viewModel.profileImage)
+    // Then the upload targets the athlete's user id
+    XCTAssertNotNil(viewModel.profileImage)
+    XCTAssertEqual(mockPhoto.lastUploadUserId, "athlete-123")
   }
 
   // MARK: - Field Validation Tests

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Schools/ViewModels/SchoolDetailViewModelPhase1Tests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Schools/ViewModels/SchoolDetailViewModelPhase1Tests.swift
@@ -399,7 +399,7 @@ final class SchoolDetailViewModelPhase1Tests: XCTestCase {
 
     XCTAssertEqual(viewModel.homeCoordinate?.latitude, 40.7128)
     XCTAssertEqual(viewModel.homeCoordinate?.longitude, -74.0060)
-    XCTAssertTrue(mockPreferenceService.fetchPreferencesCalls.contains(.location))
+    XCTAssertTrue(mockPreferenceService.fetchPreferencesCalls.contains { $0.category == .location })
   }
 
   func testLoadHomeLocation_nil_whenLongitudeMissing() async {

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Settings/ViewModels/SettingsViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Settings/ViewModels/SettingsViewModelTests.swift
@@ -6,12 +6,12 @@ final class MockPerCategoryPreferenceManager: PreferenceManaging, @unchecked Sen
   var results: [PreferenceCategory: Any?] = [:]
   var shouldThrow = false
 
-  func fetchPreferences<T: Codable>(category: PreferenceCategory) async throws -> T? {
+  func fetchPreferences<T: Codable>(category: PreferenceCategory, userId: String?) async throws -> T? {
     if shouldThrow { throw NSError(domain: "Test", code: 0) }
     return results[category] as? T
   }
 
-  func savePreferences<T: Codable>(category: PreferenceCategory, data: T) async throws -> T {
+  func savePreferences<T: Codable>(category: PreferenceCategory, userId: String?, data: T) async throws -> T {
     return data
   }
 

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Mocks/MockProfilePhotoService.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Mocks/MockProfilePhotoService.swift
@@ -7,12 +7,15 @@ final class MockProfilePhotoService: ProfilePhotoManaging, @unchecked Sendable {
   var errorToThrow: Error = NSError(domain: "MockProfilePhoto", code: 1, userInfo: [NSLocalizedDescriptionKey: "Mock error"])
 
   var stubbedUploadURL = "https://example.com/photo.jpg"
+  var stubbedCurrentURL: String?
 
   var uploadCallCount = 0
   var lastUploadUserId: String?
   var deleteCallCount = 0
   var lastDeleteUserId: String?
   var lastDeletePhotoURL: String?
+  var currentPhotoURLCallCount = 0
+  var lastCurrentPhotoURLUserId: String?
 
   func upload(image: UIImage, userId: String) async throws -> String {
     uploadCallCount += 1
@@ -26,5 +29,11 @@ final class MockProfilePhotoService: ProfilePhotoManaging, @unchecked Sendable {
     lastDeleteUserId = userId
     lastDeletePhotoURL = currentPhotoURL
     if shouldThrowOnDelete { throw errorToThrow }
+  }
+
+  func currentPhotoURL(userId: String) async throws -> String? {
+    currentPhotoURLCallCount += 1
+    lastCurrentPhotoURLUserId = userId
+    return stubbedCurrentURL
   }
 }

--- a/planning/2026-08-09-family-shared-player-profile.md
+++ b/planning/2026-08-09-family-shared-player-profile.md
@@ -1,0 +1,172 @@
+# Family-Shared Player Profile — parent can view AND edit the athlete's profile
+
+**Date:** 2026-08-09
+**Bug origin:** Family FAM-MA9G7D. Parent opens Player Profile, sees none of the player's (Owen's) data.
+**Supabase project:** `xpxzhqghxecsjhvklsqg` (shared by web + iOS).
+
+---
+
+## Root cause (confirmed with live data)
+
+Player profile = `user_preferences` row, `category='player'`, one row per `user_id`. Each family
+member has their OWN row:
+
+| Role | user_id | player row |
+|---|---|---|
+| parent | `06869a04…` | stale, 2025-12-27, partial |
+| player (Owen) | `3d97c4dc…` | rich, 2026-08-08 — the real profile |
+
+- **iOS** (`PreferenceServiceImpl.fetchPreferences`, `PreferenceServiceImpl.swift:144,149`) filters
+  `user_id = auth.uid()` (viewer). Reads AND writes viewer's own row. No athlete awareness.
+- **iOS RLS** (`user_preferences` SELECT/INSERT/UPDATE) = `auth.uid() = user_id`. Even a fixed
+  client cannot touch the athlete's row.
+- **Web** GET `/api/user/preferences/[category]` DOES redirect parent→athlete for
+  `PLAYER_OWNED_CATEGORIES = {location, player, school}` (`[category].get.ts:82-95`). But web POST
+  (`[category].post.ts:60-70`) always upserts `user_id: user.id` — **parent edits hit parent's own
+  row.** Web read works, web write is broken.
+- Web uses service-role admin client everywhere → table RLS is bypassed for web.
+
+## Design decision
+
+**Canonical player profile = the player-role member's row.** Every family member (parent + player)
+reads and writes THAT row. Different clients need different enforcement:
+
+- iOS (direct DB, RLS on) → **new RLS policies** granting family members access to the player's
+  `player`-category row + client must **target the athlete's user_id**.
+- Web (service-role, RLS off) → **app-code fix**: POST must redirect parent→athlete, same as GET.
+
+---
+
+## Phase 1 — DB: RLS + data reconciliation (shared, do first)
+
+Migration in **web repo** `supabase/migrations/` (canonical DB migrations live there), then apply to
+project `xpxzhqghxecsjhvklsqg`.
+
+### 1a. Helper (SECURITY DEFINER, non-recursive — reuses existing `get_user_family_ids()`)
+```sql
+create or replace function public.can_access_family_player_prefs(target_user uuid)
+returns boolean language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1 from family_members them
+    where them.user_id = target_user
+      and them.role = 'player'
+      and them.family_unit_id in (select family_unit_id from get_user_family_ids())
+  );
+$$;
+```
+
+### 1b. Additive policies — scoped to the three player-owned categories (`player`, `location`, `school`)
+Do NOT expose notifications / dashboard-customization / etc. — those stay private.
+```sql
+-- DECIDED: player + location + school (full web parity with PLAYER_OWNED_CATEGORIES)
+create policy "Family can view player-owned prefs" on user_preferences for select
+  using (category in ('player','location','school') and can_access_family_player_prefs(user_id));
+create policy "Family can update player-owned prefs" on user_preferences for update
+  using (category in ('player','location','school') and can_access_family_player_prefs(user_id))
+  with check (category in ('player','location','school') and can_access_family_player_prefs(user_id));
+create policy "Family can insert player-owned prefs" on user_preferences for insert
+  with check (category in ('player','location','school') and can_access_family_player_prefs(user_id));
+```
+Existing self-scoped policies stay (cover all other categories + player-self). Policies OR together.
+
+### 1c. Data reconciliation — MERGE THEN DELETE (⚠️ mutates prod data — run in a transaction)
+**DECIDED: merge-then-delete.** For each parent-role member holding a `player`/`location`/`school`
+row (per category):
+- if the linked athlete already has that category row → **delete** the parent's stale row;
+- if the athlete has none → **copy** parent's data into a new athlete-owned row first, then delete
+  the parent's.
+
+(For FAM-MA9G7D: Owen already has all rows newer/richer → parent's Dec rows are deleted.)
+Do this as a one-off migration/script over all families, idempotent, wrapped in a transaction.
+
+---
+
+## Phase 2 — iOS client (this repo)
+
+1. **`PreferenceManaging`** — add athlete targeting without breaking other callers:
+   - Real requirement: `fetchPreferences<T>(category:, userId: String?)` /
+     `savePreferences<T>(category:, userId: String?, data:)`.
+   - Protocol extension convenience `…(category:)` forwarding `userId: nil` → all existing callers
+     (school/notification/home-location VMs) unchanged.
+2. **`PreferenceServiceImpl`** — use passed `userId ?? getCurrentUserId()` in all filters/payloads.
+3. **`PlayerDetailsViewModel`** — hold a `targetUserId`; load & save against it. **Remove
+   `isReadOnly = (userRole == .parent)`** → parents edit. (`saveDetails`/`markChanged` guards drop.)
+4. **`PlayerDetailsView` / call sites** — resolve target =
+   `FamilyManager.shared.selectedAthlete?.userId ?? authManager.user?.id` (mirrors VideoLinks,
+   `SettingsView.swift:243`). Pass into the VM. Applies to `SettingsView:229` and `ProfileView:38`.
+5. **Tests** — update `MockPreferenceManager` + `PreferencePreviewMock` to new signature; update
+   `PlayerDetailsViewModelTests` (drop read-only-parent expectations, add athlete-target coverage);
+   `PreferenceServiceTests`.
+
+## Phase 3 — Web client (web repo)
+
+1. **`[category].post.ts`** — redirect parent→athlete for `PLAYER_OWNED_CATEGORIES` before upsert
+   (reuse `getLinkedAthleteId`), mirroring the GET path. Write to the athlete's row.
+2. Reconcile the legacy `player-details.patch.ts` (`assertNotParent`, "read-only view") and
+   `profile-field.patch.ts` / `canMutateAthleteData` (returns false for parents) with the new
+   parent-can-edit direction. Flag: are these used by the live form? (Explorer says the form uses
+   `player`, not `player_details`.) Likely leave unless they gate a used field.
+
+## Phase 4 — Photo (INCLUDED — decided in scope)
+
+Currently iOS photo is **in-memory only** (`PlayerDetailsViewModel.uploadProfilePhoto:142`) — never
+persisted anywhere, no DB field. Web stores it in `users.profile_photo_url` + Storage bucket
+`profile-photos`, keyed to logged-in user (no athlete redirect). Target: family-shared photo on the
+athlete's record.
+
+### 4a. DB (migration in web repo, apply to shared project)
+- **Read:** family members must read the athlete's `users.profile_photo_url`. Add a family SELECT
+  path — prefer a SECURITY DEFINER RPC `get_athlete_profile_photo(athlete uuid)` (or a narrow
+  family SELECT policy on `users`) so we don't broaden general `users` read access.
+- **Write:** parent must set the athlete's photo. Prefer SECURITY DEFINER RPC
+  `set_athlete_profile_photo(athlete uuid, url text)` that checks
+  `can_access_family_player_prefs(athlete)` — avoids a broad UPDATE policy on `users` (column-level
+  restriction isn't native to RLS).
+- **Storage:** bucket `profile-photos` RLS must allow a family member to upload/delete under the
+  athlete's prefix `<athleteUserId>/…` (policy keyed via `can_access_family_player_prefs`).
+
+### 4b. iOS
+- Real Storage upload to `profile-photos/<athleteUserId>/…` (mirror `InteractionsServiceImpl`
+  storage pattern), then persist via `set_athlete_profile_photo`. Load via the read path on profile
+  open. Replace the in-memory-only `uploadProfilePhoto`/`deleteProfilePhoto`.
+
+### 4c. Web
+- Redirect photo read/write to the athlete in `useProfile.ts` (upload path, `getPublicUrl`, the
+  `users.profile_photo_url` update, and delete) when a parent is viewing. Reuse `getLinkedAthleteId`.
+
+---
+
+## Verification
+- SQL: as parent, `select` + `update` athlete's `player` row succeeds; other categories still blocked.
+- iOS: parent opens Player Profile → sees Owen's data; edits save to Owen's row; player self-edit
+  unchanged. `xcodebuild test` affected classes green.
+- Web: parent edit persists to athlete's row.
+- Re-check FAM-MA9G7D: both members see the single canonical (Owen's) profile.
+
+## STATUS: Phases 1–4 COMPLETE (2026-08-09)
+- **Phase 1 (DB)** — applied to prod `xpxzhqghxecsjhvklsqg`: helper `can_access_family_player_prefs`,
+  additive RLS on `user_preferences` (player/location/school), merge-then-delete reconciliation
+  (4 rows). Verified: parent reads/writes athlete rows; private categories + strangers blocked.
+  Migrations: `20260821000000_family_shared_player_prefs_rls.sql`,
+  `20260821000100_reconcile_parent_player_owned_prefs.sql` (in web repo).
+- **Phase 2 (iOS)** — `PreferenceManaging.userId` targeting; `PlayerDetailsViewModel` loads/saves
+  athlete row; parents edit. Build + tests green.
+- **Phase 3 (web)** — `server/utils/playerOwnedPreferences.ts`; GET+POST redirect parent→athlete.
+  Typecheck + unit tests green.
+- **Phase 4 (photo)** — DB: `set_athlete_profile_photo` RPC (self OR family-athlete) +
+  storage family-write policies (`20260821000200`, `..._allow_self`). iOS: `ProfilePhotoService`
+  persists via RPC + `currentPhotoURL`; Player Profile shows/edits athlete's real photo. Web:
+  `useProfilePhoto` targets athlete via RPC; player-details un-gated (parents edit); e2e restriction
+  spec inverted. All verified.
+- **Remaining gap:** iOS `SchoolPreferences`/`HomeLocation` VMs still self-scope (RLS + web allow
+  parent for location/school; iOS client doesn't thread `targetUserId` yet). Player-profile bug fixed.
+- **Not committed.** iOS on `main` checkout (needs a branch); web on `feat/family-shared-player-profile`.
+
+## Decisions locked (2026-08-09)
+1. Reconciliation: **merge-then-delete** parent-role rows (1c).
+2. Categories: **player + location + school** (full web parity).
+3. Photo: **included** (Phase 4).
+
+## Remaining note
+- Multi-athlete families: iOS uses `selectedAthlete`; web derives the single player-role member
+  (no switcher). Fine for single-athlete families; multi-athlete web needs a switcher later.


### PR DESCRIPTION
## What & why
Bug: a parent saw none of the athlete's player-profile data. Root cause: player-owned prefs
(`player`/`location`/`school`) + the profile photo were stored per-`auth.uid()`, so each family
member had their own row; a parent read/wrote their own (empty) row. Fix: the **player-role
member's row is the single canonical copy; the whole family reads and edits it** (parents
collaborate, not read-only).

## iOS changes
- `PreferenceManaging` gains optional `userId` targeting (extension keeps existing callers
  unchanged); `PreferenceServiceImpl` resolves `target ?? current user`.
- `PlayerDetailsViewModel` loads/saves the athlete's row via `targetUserId`; parents are full
  editors (dropped read-only).
- `ProfilePhotoService` persists via the `set_athlete_profile_photo` RPC (self or family athlete)
  + `currentPhotoURL`; the Player Profile screen shows/edits the athlete's real, family-shared photo
  (was in-memory only).
- Parity threading: `HomeLocation`/`SchoolPreferences` view models + Schools distance-from-home +
  Timeline now read the athlete's row via `selectedAthlete?.userId`. Onboarding/InviteJoin stay
  self-scoped.

## DB + web
RLS, reconciliation, RPC, and the web parity (API redirect, un-gated player-details, photo) land in
`recruiting-compass-web` PR (same branch name). DB migrations already applied to the shared Supabase
project.

## Testing
`xcodebuild build` clean. Affected test classes green: PlayerDetails, PreferenceService,
SettingsViewModel, SchoolPreferences, HomeLocation, SchoolDetail, SchoolsList, Timeline,
NotificationPreferences.

## Note
Includes other sessions' unpushed `main` commits (doc-cleanup) that this branch was cut on top of.

https://claude.ai/code/session_01AFmKmQxRdpfnKzLbsLRLjP