### PR TITLE
fix(profile): unify completeness formula with web (canonical weighted spec)

### DIFF
--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Analytics/Components/PieChartView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Analytics/Components/PieChartView.swift
@@ -48,6 +48,7 @@ struct PieChartView: View {
     }.joined(separator: "; ")
   }
 
+  @ViewBuilder
   private var pieRing: some View {
     let diameter: CGFloat = 160
     let radius = diameter / 2

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Models/SuggestionHelpContent.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Models/SuggestionHelpContent.swift
@@ -94,6 +94,7 @@ struct SuggestionHelpContent {
     ),
     "official-visit": SuggestionHelpContent(
       title: String(localized: "Schedule Official Visits"),
+      // swiftlint:disable:next line_length
       whyItMatters: String(localized: "Official visits are critical for late-stage recruiting (junior/senior year). They give coaches the chance to evaluate you academically and athletically at their campus, and they give you the chance to assess whether the school is truly a fit. Many scholarship decisions happen during or after official visits."),
       howToComplete: [
         String(localized: "Identify your top 3-5 schools based on fit and genuine interest"),

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Events/Components/EventRowView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Events/Components/EventRowView.swift
@@ -49,6 +49,7 @@ struct EventRowView: View {
     .padding(.vertical, 4)
   }
 
+  @ViewBuilder
   private var typeBadge: some View {
     let eventType = EventType(rawValue: event.type)
     return Text(eventType?.displayName ?? event.type)
@@ -61,6 +62,7 @@ struct EventRowView: View {
       .clipShape(Capsule())
   }
 
+  @ViewBuilder
   private var statusBadge: some View {
     let label = event.attended
       ? String(localized: "Attended")

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/HomeLocation.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/HomeLocation.swift
@@ -8,6 +8,13 @@ struct HomeLocation: Codable, Equatable, Sendable {
   var latitude: Double?
   var longitude: Double?
 
+  /// Home location counts as "set" for profile completeness when a zip is present
+  /// or a geocoded coordinate pair exists. Canonical rule shared with web.
+  var isSet: Bool {
+    !(zip ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      || (latitude != nil && longitude != nil)
+  }
+
   static var `default`: HomeLocation {
     HomeLocation(
       address: nil,

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift
@@ -69,33 +69,34 @@ struct PlayerDetails: Codable, Equatable, Sendable {
     return sport == "baseball" || sport == "softball"
   }
 
-  /// Fraction (0.0–1.0) of required profile fields that are filled. Single source
-  /// of truth for both the Player Details completeness card and the Settings badge.
-  /// SAT and ACT count as one field — most athletes take only one.
-  var completenessScore: Double {
-    var fields: [Bool] = [
-      graduationYear != nil,
-      !(highSchool ?? "").isEmpty,
-      !(primarySport ?? "").isEmpty,
-      !(schoolName ?? "").isEmpty,
-      !(schoolCity ?? "").isEmpty,
-      !(schoolState ?? "").isEmpty,
-      heightInches != nil,
-      weightLbs != nil,
-      gpa != nil,
-      satScore != nil || actScore != nil,
-      !(twitterHandle ?? "").isEmpty || !(instagramHandle ?? "").isEmpty
-    ]
-    if isBaseballOrSoftball {
-      fields.append(bats != nil)
-      fields.append(throws_ != nil)
+  /// Weighted profile completeness (0.0–1.0). Canonical formula shared with the web
+  /// app — see `planning/2026-08-09-profile-completeness-canonical-spec.md`.
+  ///
+  /// `hasHighlightVideo` and `hasHomeLocation` live outside the player-prefs blob
+  /// (the `video_links` table and the location store), so the caller fetches them
+  /// and passes them in — keeping this function pure and unit-testable.
+  func completenessScore(hasHighlightVideo: Bool, hasHomeLocation: Bool) -> Double {
+    func filled(_ s: String?) -> Bool {
+      !(s ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
-    let filled = fields.count(where: { $0 })
-    return Double(filled) / Double(fields.count)
+    var score = 0.0
+    if graduationYear != nil { score += 0.10 }
+    if filled(primarySport) { score += 0.10 }
+    if filled(primaryPosition) { score += 0.10 }
+    if hasHomeLocation { score += 0.10 }
+    if gpa != nil { score += 0.15 }
+    if satScore != nil || actScore != nil { score += 0.10 }
+    if hasHighlightVideo { score += 0.15 }
+    if heightInches != nil { score += 0.05 }
+    if weightLbs != nil { score += 0.05 }
+    if filled(phone) { score += 0.10 }
+    return score
   }
 
-  /// True only when every required field is filled. Drives the Settings "Complete" badge.
-  var isComplete: Bool { completenessScore >= 1.0 }
+  /// True only when every canonical field is filled. Drives the Settings "Complete" badge.
+  func isComplete(hasHighlightVideo: Bool, hasHomeLocation: Bool) -> Bool {
+    completenessScore(hasHighlightVideo: hasHighlightVideo, hasHomeLocation: hasHomeLocation) >= 1.0
+  }
 
   enum CodingKeys: String, CodingKey {
     case graduationYear = "graduation_year"

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
@@ -24,6 +24,12 @@ final class PlayerDetailsViewModel {
     var hapticSuccessTrigger = 0
     var selectedTab: Int = 0
 
+    /// Whether the athlete has ≥1 highlight video (`video_links` table) — feeds the
+    /// canonical completeness score. Fetched on load; defaults false.
+    var hasHighlightVideo = false
+    /// Whether the athlete's home location is set — feeds the completeness score.
+    var hasHomeLocation = false
+
     // Backward-compat computed wrappers (existing tests use these)
     var isSaving: Bool { saveStatus == .saving }
     var hasUnsavedChanges: Bool { saveStatus == .saving }
@@ -31,10 +37,16 @@ final class PlayerDetailsViewModel {
 
     private let preferenceService: any PreferenceManaging
     private let photoService: any ProfilePhotoManaging
+    private let videoLinksService: any VideoLinksManaging
+    private let authManager: any AuthManaging
     /// Whose player profile this VM reads/writes. `nil` = the current user's own row.
     /// A parent viewing the family athlete passes the athlete's user id so the whole
     /// family reads and edits the single canonical player row (RLS-gated).
     private let targetUserId: String?
+
+    /// The athlete whose video/location we score: the explicit target, else the
+    /// signed-in user (a player viewing their own profile).
+    private var effectiveUserId: String? { targetUserId ?? authManager.user?.id }
     @ObservationIgnored nonisolated(unsafe) private var pendingAutoSave: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var pendingStatusReset: Task<Void, Never>?
 
@@ -42,10 +54,14 @@ final class PlayerDetailsViewModel {
         preferenceService: any PreferenceManaging,
         userRole: UserRole,
         targetUserId: String? = nil,
-        photoService: any ProfilePhotoManaging = ProfilePhotoServiceImpl()
+        photoService: any ProfilePhotoManaging = ProfilePhotoServiceImpl(),
+        videoLinksService: any VideoLinksManaging = VideoLinksServiceImpl(),
+        authManager: any AuthManaging = AuthManager.shared
     ) {
         self.preferenceService = preferenceService
         self.photoService = photoService
+        self.videoLinksService = videoLinksService
+        self.authManager = authManager
         self.targetUserId = targetUserId
         // Parents and players collaborate on the same player profile; everyone can edit.
         self.isReadOnly = false
@@ -58,7 +74,9 @@ final class PlayerDetailsViewModel {
 
     // MARK: - Completeness
 
-    var completenessScore: Double { details.completenessScore }
+    var completenessScore: Double {
+        details.completenessScore(hasHighlightVideo: hasHighlightVideo, hasHomeLocation: hasHomeLocation)
+    }
 
     var isBaseballOrSoftball: Bool { details.isBaseballOrSoftball }
 
@@ -103,6 +121,32 @@ final class PlayerDetailsViewModel {
             errorMessage = String(localized: "Failed to load player details. Please try again.")
         }
         await loadPhoto()
+        await loadCompletenessInputs()
+    }
+
+    /// Fetches the two completeness signals that live outside the player-prefs blob:
+    /// a highlight video (`video_links` table) and a set home location. Failures are
+    /// non-fatal — the score just treats the signal as absent.
+    func loadCompletenessInputs() async {
+        do {
+            let loc: HomeLocation? = try await preferenceService.fetchPreferences(
+                category: .location, userId: targetUserId)
+            hasHomeLocation = loc?.isSet ?? false
+        } catch {
+            logger.error("Failed to load home location for completeness: \(error.localizedDescription)")
+            hasHomeLocation = false
+        }
+
+        guard let userId = effectiveUserId else {
+            hasHighlightVideo = false
+            return
+        }
+        do {
+            hasHighlightVideo = try await !videoLinksService.fetchVideoLinks(userId: userId).isEmpty
+        } catch {
+            logger.error("Failed to load video links for completeness: \(error.localizedDescription)")
+            hasHighlightVideo = false
+        }
     }
 
     /// Loads the athlete's persisted, family-shared profile photo URL for display.

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -17,19 +17,39 @@ final class SettingsViewModel {
   var schoolPreferencesStatus: SettingsBadgeStatus?
 
   private let preferenceService: any PreferenceManaging
+  private let videoLinksService: any VideoLinksManaging
+  private let authManager: any AuthManaging
 
-  init(preferenceService: any PreferenceManaging) {
+  init(
+    preferenceService: any PreferenceManaging,
+    videoLinksService: any VideoLinksManaging = VideoLinksServiceImpl(),
+    authManager: any AuthManaging = AuthManager.shared
+  ) {
     self.preferenceService = preferenceService
+    self.videoLinksService = videoLinksService
+    self.authManager = authManager
   }
 
   func loadCompletionStatus() async {
     logger.debug("Loading completion status for settings badges")
 
-    homeLocationStatus = await fetchForStatus(category: .location) { (loc: HomeLocation) in
-      loc.latitude != nil && loc.longitude != nil
+    // Fetch location once: drives both the location badge (needs coordinates) and
+    // the player-completeness home-location signal (zip OR coordinates). A fetch
+    // error leaves the badge nil (hidden), matching the other badges' semantics.
+    var hasHomeLocation = false
+    do {
+      let location: HomeLocation? = try await preferenceService.fetchPreferences(category: .location)
+      homeLocationStatus = location.map { ($0.latitude != nil && $0.longitude != nil) ? .complete : .incomplete }
+        ?? .incomplete
+      hasHomeLocation = location?.isSet ?? false
+    } catch {
+      logger.error("Failed to fetch location badge status: \(error.localizedDescription)")
+      homeLocationStatus = nil
     }
+
+    let hasHighlightVideo = await fetchHasHighlightVideo()
     playerDetailsStatus = await fetchForStatus(category: .player) { (details: PlayerDetails) in
-      details.isComplete
+      details.isComplete(hasHighlightVideo: hasHighlightVideo, hasHomeLocation: hasHomeLocation)
     }
     schoolPreferencesStatus = await fetchForStatus(category: .school) { (prefs: SchoolPreferences) in
       !prefs.preferences.isEmpty
@@ -42,6 +62,17 @@ final class SettingsViewModel {
   }
 
   // MARK: - Private
+
+  /// Whether the signed-in athlete has ≥1 highlight video. Non-fatal on failure.
+  private func fetchHasHighlightVideo() async -> Bool {
+    guard let userId = authManager.user?.id else { return false }
+    do {
+      return try await !videoLinksService.fetchVideoLinks(userId: userId).isEmpty
+    } catch {
+      logger.error("Failed to fetch video links for badge: \(error.localizedDescription)")
+      return false
+    }
+  }
 
   /// Returns nil if fetch throws (badge stays hidden), .incomplete if no data, .complete/.incomplete based on predicate
   private func fetchForStatus<T: Codable>(

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/VideoLinks/Views/VideoLinksEditorView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/VideoLinks/Views/VideoLinksEditorView.swift
@@ -95,6 +95,7 @@ struct VideoLinksEditorView: View {
 
   // MARK: - Links List
 
+  @ViewBuilder
   private var linksList: some View {
     List {
       ForEach(viewModel.links) { link in

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Models/PlayerDetailsCompletenessTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/Models/PlayerDetailsCompletenessTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import TheRecruitingCompass
+
+/// Canonical profile-completeness formula — see
+/// `planning/2026-08-09-profile-completeness-canonical-spec.md`. Weights must match
+/// the web implementation (`utils/profileCompletenessCalculation.ts`).
+final class PlayerDetailsCompletenessTests: XCTestCase {
+  nonisolated deinit {}
+
+  private func score(_ d: PlayerDetails, video: Bool = false, location: Bool = false) -> Double {
+    d.completenessScore(hasHighlightVideo: video, hasHomeLocation: location)
+  }
+
+  func testEmptyProfileIsZero() {
+    XCTAssertEqual(score(PlayerDetails()), 0.0, accuracy: 0.0001)
+  }
+
+  func testEachFieldContributesItsWeight() {
+    XCTAssertEqual(score(PlayerDetails(graduationYear: 2026)), 0.10, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(primarySport: "Soccer")), 0.10, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(primaryPosition: "Forward")), 0.10, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(gpa: 3.5)), 0.15, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(satScore: 1200)), 0.10, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(actScore: 28)), 0.10, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(heightInches: 70)), 0.05, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(weightLbs: 160)), 0.05, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(phone: "555-1234")), 0.10, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(), video: true), 0.15, accuracy: 0.0001)
+    XCTAssertEqual(score(PlayerDetails(), location: true), 0.10, accuracy: 0.0001)
+  }
+
+  func testSatAndActCountAsOneField() {
+    let both = PlayerDetails(satScore: 1200, actScore: 28)
+    XCTAssertEqual(score(both), 0.10, accuracy: 0.0001)
+  }
+
+  func testWhitespaceStringsAreNotCounted() {
+    let d = PlayerDetails(primarySport: "  ", primaryPosition: "\n", phone: " ")
+    XCTAssertEqual(score(d), 0.0, accuracy: 0.0001)
+  }
+
+  func testNonCanonicalFieldsDoNotContribute() {
+    let d = PlayerDetails(
+      highSchool: "HS", primarySport: nil, bats: "R", throws_: "R",
+      twitterHandle: "@x", schoolName: "S", schoolCity: "C", schoolState: "TX"
+    )
+    XCTAssertEqual(score(d), 0.0, accuracy: 0.0001)
+  }
+
+  func testAllFieldsSumToOne() {
+    let d = PlayerDetails(
+      graduationYear: 2026, primarySport: "Soccer", primaryPosition: "Forward",
+      heightInches: 70, weightLbs: 160, gpa: 3.5, satScore: 1200, phone: "555-1234"
+    )
+    XCTAssertEqual(score(d, video: true, location: true), 1.0, accuracy: 0.0001)
+    XCTAssertTrue(d.isComplete(hasHighlightVideo: true, hasHomeLocation: true))
+  }
+
+  func testIsCompleteFalseWhenAnyMissing() {
+    let d = PlayerDetails(
+      graduationYear: 2026, primarySport: "Soccer", primaryPosition: "Forward",
+      heightInches: 70, weightLbs: 160, gpa: 3.5, satScore: 1200, phone: "555-1234"
+    )
+    XCTAssertFalse(d.isComplete(hasHighlightVideo: false, hasHomeLocation: true))
+  }
+}
+
+final class HomeLocationPresenceTests: XCTestCase {
+  nonisolated deinit {}
+
+  func testEmptyIsNotSet() {
+    XCTAssertFalse(HomeLocation().isSet)
+  }
+
+  func testZipMakesItSet() {
+    XCTAssertTrue(HomeLocation(zip: "60601").isSet)
+  }
+
+  func testBlankZipIsNotSet() {
+    XCTAssertFalse(HomeLocation(zip: "  ").isSet)
+  }
+
+  func testCoordinatePairMakesItSet() {
+    XCTAssertTrue(HomeLocation(latitude: 41.8, longitude: -87.6).isSet)
+  }
+
+  func testLoneLatitudeIsNotSet() {
+    XCTAssertFalse(HomeLocation(latitude: 41.8).isSet)
+  }
+}

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/ViewModels/PlayerDetailsViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/ViewModels/PlayerDetailsViewModelTests.swift
@@ -358,21 +358,69 @@ final class PlayerDetailsViewModelTests: XCTestCase {
     XCTAssertEqual(viewModel.completenessScore, 0.0)
   }
 
-  func testCompletenessScore_WithManyFieldsFilled_IsHigh() {
+  func testCompletenessScore_AllCanonicalFieldsFilled_IsOne() {
     viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .player)
     viewModel.details.graduationYear = 2026
-    viewModel.details.highSchool = "Test High"
     viewModel.details.primarySport = "Soccer"
+    viewModel.details.primaryPosition = "Forward"
+    viewModel.details.gpa = 3.8
+    viewModel.details.satScore = 1350
+    viewModel.details.heightInches = 72
+    viewModel.details.weightLbs = 180
+    viewModel.details.phone = "555-1234"
+    viewModel.hasHighlightVideo = true
+    viewModel.hasHomeLocation = true
+    XCTAssertEqual(viewModel.completenessScore, 1.0, accuracy: 0.0001)
+  }
+
+  func testCompletenessScore_IgnoresNonCanonicalFields() {
+    // School/social/physical-bats fields are NOT part of the canonical formula.
+    viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .player)
+    viewModel.details.highSchool = "Test High"
     viewModel.details.schoolName = "Test School"
     viewModel.details.schoolCity = "Austin"
     viewModel.details.schoolState = "TX"
-    viewModel.details.heightInches = 72
-    viewModel.details.weightLbs = 180
-    viewModel.details.gpa = 3.8
-    viewModel.details.satScore = 1350
-    viewModel.details.actScore = 30
     viewModel.details.twitterHandle = "@test"
-    XCTAssertGreaterThan(viewModel.completenessScore, 0.8)
+    viewModel.details.bats = "R"
+    XCTAssertEqual(viewModel.completenessScore, 0.0, accuracy: 0.0001)
+  }
+
+  func testLoadCompletenessInputs_WiresVideoAndLocationFromStores() async throws {
+    let mockVideo = MockVideoLinksService()
+    _ = try await mockVideo.createVideoLink(
+      VideoLinkCreateRequest(
+        userId: "athlete1", familyUnitId: nil, platform: .youtube,
+        url: "https://youtu.be/x", title: nil, position: 0))
+    mockService.fetchPreferencesResult = .success(HomeLocation(zip: "60601"))
+
+    viewModel = PlayerDetailsViewModel(
+      preferenceService: mockService, userRole: .parent,
+      targetUserId: "athlete1", photoService: mockPhoto, videoLinksService: mockVideo)
+
+    await viewModel.loadCompletenessInputs()
+
+    XCTAssertTrue(viewModel.hasHomeLocation)
+    XCTAssertTrue(viewModel.hasHighlightVideo)
+  }
+
+  func testLoadCompletenessInputs_AbsentStores_LeaveFlagsFalse() async {
+    let mockVideo = MockVideoLinksService()  // no links
+    mockService.fetchPreferencesResult = .success(nil)  // no location
+    viewModel = PlayerDetailsViewModel(
+      preferenceService: mockService, userRole: .parent,
+      targetUserId: "athlete1", photoService: mockPhoto, videoLinksService: mockVideo)
+
+    await viewModel.loadCompletenessInputs()
+
+    XCTAssertFalse(viewModel.hasHomeLocation)
+    XCTAssertFalse(viewModel.hasHighlightVideo)
+  }
+
+  func testCompletenessScore_VideoAndLocationContributeWeights() {
+    viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .player)
+    viewModel.hasHighlightVideo = true  // 15%
+    viewModel.hasHomeLocation = true    // 10%
+    XCTAssertEqual(viewModel.completenessScore, 0.25, accuracy: 0.0001)
   }
 
   func testNormalizePositions_TitleCasesAll() {

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Settings/ViewModels/SettingsViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Settings/ViewModels/SettingsViewModelTests.swift
@@ -23,17 +23,35 @@ final class SettingsViewModelTests: XCTestCase {
   nonisolated deinit {}
   var viewModel: SettingsViewModel!
   var mockService: MockPerCategoryPreferenceManager!
+  var mockVideo: MockVideoLinksService!
+  var mockAuth: MockAuthManager!
 
   override func setUp() async throws {
     try await super.setUp()
     mockService = MockPerCategoryPreferenceManager()
-    viewModel = SettingsViewModel(preferenceService: mockService)
+    mockVideo = MockVideoLinksService()
+    mockAuth = MockAuthManager()
+    viewModel = SettingsViewModel(
+      preferenceService: mockService, videoLinksService: mockVideo, authManager: mockAuth)
   }
 
   override func tearDown() {
     viewModel = nil
     mockService = nil
+    mockVideo = nil
+    mockAuth = nil
     super.tearDown()
+  }
+
+  /// Marks the signed-in athlete as having a highlight video (feeds the "Complete" badge).
+  private func giveAthleteHighlightVideo(userId: String = "athlete-1") async throws {
+    mockAuth.user = User(
+      id: userId, email: "a@example.com", emailConfirmedAt: nil, phone: nil,
+      createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z", role: .player)
+    _ = try await mockVideo.createVideoLink(
+      VideoLinkCreateRequest(
+        userId: userId, familyUnitId: nil, platform: .youtube,
+        url: "https://youtu.be/x", title: nil, position: 0))
   }
 
   // MARK: - Initial state
@@ -89,10 +107,24 @@ final class SettingsViewModelTests: XCTestCase {
     XCTAssertEqual(viewModel.playerDetailsStatus, .incomplete)
   }
 
-  func testPlayerDetailsStatus_AllRequiredFieldsFilled_IsComplete() async {
+  func testPlayerDetailsStatus_AllRequiredFieldsFilled_IsComplete() async throws {
+    // Canonical completeness also needs a home location and a highlight video —
+    // both live outside the player-prefs blob.
     mockService.results[.player] = PlayerDetails.fullyComplete
+    mockService.results[.location] = HomeLocation(
+      address: nil, city: nil, state: nil, zip: "60601", latitude: nil, longitude: nil)
+    try await giveAthleteHighlightVideo()
     await viewModel.loadCompletionStatus()
     XCTAssertEqual(viewModel.playerDetailsStatus, .complete)
+  }
+
+  func testPlayerDetailsStatus_AllFieldsButNoVideo_IsIncomplete() async {
+    mockService.results[.player] = PlayerDetails.fullyComplete
+    mockService.results[.location] = HomeLocation(
+      address: nil, city: nil, state: nil, zip: "60601", latitude: nil, longitude: nil)
+    // no video, no auth user
+    await viewModel.loadCompletionStatus()
+    XCTAssertEqual(viewModel.playerDetailsStatus, .incomplete)
   }
 
   func testPlayerDetailsStatus_EmptyDetails_IsIncomplete() async {
@@ -147,7 +179,7 @@ final class SettingsViewModelTests: XCTestCase {
 
   // MARK: - Parallel loading
 
-  func testLoadCompletionStatus_AllThreeLoaded_AllStatusesSet() async {
+  func testLoadCompletionStatus_AllThreeLoaded_AllStatusesSet() async throws {
     let details = PlayerDetails.fullyComplete
     mockService.results[.location] = HomeLocation(
       address: nil, city: nil, state: nil, zip: nil,
@@ -155,6 +187,7 @@ final class SettingsViewModelTests: XCTestCase {
     )
     mockService.results[.player] = details
     mockService.results[.school] = SchoolPreferences(preferences: [], templateUsed: nil, lastUpdated: nil)
+    try await giveAthleteHighlightVideo()
 
     await viewModel.loadCompletionStatus()
 
@@ -169,16 +202,13 @@ extension PlayerDetails {
   static var fullyComplete: PlayerDetails {
     var details = PlayerDetails()
     details.graduationYear = 2027
-    details.highSchool = "Central High"
     details.primarySport = "Soccer"
-    details.schoolName = "Central High School"
-    details.schoolCity = "Austin"
-    details.schoolState = "TX"
+    details.primaryPosition = "Forward"
     details.heightInches = 70
     details.weightLbs = 160
     details.gpa = 3.8
     details.satScore = 1350
-    details.instagramHandle = "@player"
+    details.phone = "555-1234"
     return details
   }
 }

--- a/planning/2026-08-09-profile-completeness-canonical-spec.md
+++ b/planning/2026-08-09-profile-completeness-canonical-spec.md
@@ -1,0 +1,75 @@
+# Profile Completeness — Canonical Spec (v1)
+
+**Date:** 2026-08-09
+**Bug:** iOS showed 92% complete (parent view), web showed 55% (player view) for the
+same athlete. Expected identical.
+
+## Root cause
+
+Two independent, divergent implementations:
+
+1. **iOS** (`PlayerDetails.completenessScore`) — equal-weight 11-field formula
+   (school name/city/state, height, weight, social handles, bats/throws…). Fills
+   easily from onboarding → inflated to 92%.
+
+2. **Web** (`utils/profileCompletenessCalculation.ts`) — weighted 9-field formula,
+   but **3 of its 9 fields (35% of total weight) read from sources nothing
+   populates**:
+   - `zip_code` (10%) — onboarding saves zip to the **home-location** store
+     (`setHomeLocation`), never to the player-prefs blob the calc reads → always 0.
+   - `highlight_video_url` (15%) — written **nowhere** in the app; real video data
+     lives in the `video_links` table → always 0.
+   - `athletic_stats` (10%) — written **nowhere** → always 0.
+
+   Web is therefore capped at ~65%. Example athlete scored exactly 55
+   (gradYear 10 + sport 10 + position 10 + gpa 15 + testScores 10), phone missing.
+
+Both are wrong: iOS over-counts easy fields; web has 35% unearnable dead weight.
+
+## Canonical formula (both platforms)
+
+Weighted fields summing to 100%. Weights preserve web's original intent; the 3
+broken sources are re-wired to real data. `athletic_stats` (10%) is split into
+height 5% + weight 5% (real fields both platforms already store).
+
+| Field | Weight | Source | Present when |
+|---|---|---|---|
+| Graduation year | 10% | player prefs `graduation_year` | non-null |
+| Primary sport | 10% | player prefs `primary_sport` | non-empty (trimmed) |
+| Primary position | 10% | player prefs `primary_position` | non-empty (trimmed) |
+| Home location | 10% | location store (`HomeLocation`) | `zip` non-empty **OR** both `latitude`+`longitude` set |
+| GPA | 15% | player prefs `gpa` | non-null |
+| Test scores | 10% | player prefs `sat_score` **or** `act_score` | either non-null |
+| Highlight video | 15% | `video_links` table | ≥1 row for the athlete |
+| Height | 5% | player prefs `height_inches` | non-null |
+| Weight | 5% | player prefs `weight_lbs` | non-null |
+| Contact | 10% | player prefs `phone` | non-empty (trimmed) |
+
+**Total: 100%.** Result is a fraction 0.0–1.0 (iOS) / integer 0–100 (web),
+rounded to nearest integer for display.
+
+### Purity / async note
+
+Highlight-video and home-location presence live **outside** the player-prefs blob,
+so the pure formula cannot read them from `PlayerDetails` alone. Both platforms:
+
+1. Async-fetch two booleans — `hasHighlightVideo` (video_links count > 0) and
+   `hasHomeLocation` (location store) — in the ViewModel/composable.
+2. Pass them into a **pure** calc function alongside the player-prefs object.
+
+Keeps the scoring function pure and unit-testable; side-effectful fetches stay in
+the caller.
+
+## Presence rules
+
+- Strings: trimmed, non-empty.
+- Numbers: non-null. (Do **not** treat 0 as missing for gpa/height/weight — 0 is
+  invalid for these anyway, but null is the "unset" signal, matching iOS optionals.)
+- Home location: `zip` non-empty OR (`latitude` && `longitude`).
+- Highlight video: at least one `video_links` row owned by the athlete.
+
+## Out of scope
+
+- Reordering onboarding to collect zip into the player blob (location store is the
+  canonical home for it — the fix reads from there instead).
+- Changing weights beyond the athletic_stats split.


### PR DESCRIPTION
## Bug
Player profile showed **92% complete on iOS** (parent view) vs **55% on web** (player view) for the same athlete.

## Root cause
Two divergent implementations — neither correct:
- **iOS**: equal-weight 11-field formula weighted toward easy onboarding fields (school name/city/state, height, social, bats/throws) → inflated to 92%.
- **Web**: weighted 9-field formula where **35% of the weight** (`zip_code`, `highlight_video_url`, `athletic_stats`) read from sources nothing populates → capped at ~65%, athlete landed at 55.

## Fix
One canonical weighted spec, shared with web (companion PR in recruiting-compass-web). Weights preserved from web; the 3 dead fields re-wired to real data; `athletic_stats`→height/weight.

| Field | Wt | Field | Wt |
|---|--|---|--|
| Graduation year | 10% | Test scores (SAT/ACT) | 10% |
| Primary sport | 10% | Highlight video (video_links) | 15% |
| Primary position | 10% | Height | 5% |
| Home location (zip/coords) | 10% | Weight | 5% |
| GPA | 15% | Contact (phone) | 10% |

Video + home location live outside the player-prefs blob, so the ViewModels fetch them as booleans and feed a pure scoring function.

Spec: `planning/2026-08-09-profile-completeness-canonical-spec.md`

## Test plan
- `xcodebuild build-for-testing` clean.
- Affected suites: **63/63 pass** — `PlayerDetailsCompletenessTests`, `HomeLocationPresenceTests`, `PlayerDetailsViewModelTests`, `SettingsViewModelTests`.

> Stacked on `feat/family-shared-player-profile` (unmerged). Retarget to `main` after the feature merges.

https://claude.ai/code/session_01R1HZvjzRQq3hWcKDmBBvre

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated profile completeness scoring with standardized field weights.
  * Highlight videos and home locations now contribute to profile completion.
  * Home location status recognizes valid ZIP codes or complete coordinates.
  * Settings and profile views reflect location and highlight-video completion.

* **Bug Fixes**
  * Improved handling of blank or whitespace-only profile fields.
  * Missing location or video information safely appears as incomplete.

* **Documentation**
  * Added a shared specification for consistent profile-completeness calculations across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->