### PR TITLE
feat(profile): Player Profile tab reorganization + web parity (iOS)

### DIFF
--- a/TheRecruitingCompass/TheRecruitingCompass/Core/Utilities/CanonicalPositions.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Core/Utilities/CanonicalPositions.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Canonical, sport-scoped athlete positions. Swift mirror of web
+/// `utils/positions/canonical.ts` (shipped in web PR #354). Web is the source of
+/// truth; the shared DB is already backfilled to these full-name values.
+///
+/// "Infielder"/"Outfielder" are not real positions — they collapse to `Utility`.
+enum CanonicalPositions {
+  /// One canonical vocabulary per sport (full names, granular). Keys match the
+  /// sport strings used across onboarding/preferences.
+  static let bySport: [String: [String]] = [
+    "Baseball": baseball,
+    "Softball": baseball,
+    "Basketball": ["Point Guard", "Shooting Guard", "Small Forward", "Power Forward", "Center"],
+    "Football": ["Quarterback", "Running Back", "Wide Receiver", "Tight End", "Offensive Line",
+                 "Defensive Line", "Linebacker", "Defensive Back", "Kicker", "Punter"],
+    "Soccer": ["Goalkeeper", "Defender", "Midfielder", "Forward"],
+    "Volleyball": ["Outside Hitter", "Middle Blocker", "Setter", "Libero",
+                   "Opposite Hitter", "Defensive Specialist"],
+    "Track & Field": ["Sprinter", "Distance Runner", "Jumper", "Thrower", "Hurdler"],
+    "Swimming": ["Freestyle", "Backstroke", "Breaststroke", "Butterfly", "Individual Medley", "Diver"],
+    "Cross Country": ["Runner"],
+    "Tennis": ["Singles", "Doubles"],
+    "Golf": ["Golfer"],
+    "Lacrosse": ["Attackman", "Midfielder", "Defenseman", "Goalie"],
+    "Field Hockey": ["Forward", "Midfielder", "Defender", "Goalkeeper"],
+    "Ice Hockey": ["Forward", "Defenseman", "Goalie"],
+    "Wrestling": ["Wrestler"],
+    "Rowing": ["Rower"],
+    "Water Polo": ["Field Player", "Goalkeeper"]
+  ]
+
+  private static let baseball = ["Pitcher", "Catcher", "First Base", "Second Base", "Third Base",
+                                 "Shortstop", "Left Field", "Center Field", "Right Field",
+                                 "Designated Hitter", "Utility"]
+
+  /// Canonical options for a sport (case-insensitive lookup). Empty when the
+  /// sport is nil/unknown (e.g. "Other").
+  static func positions(for sport: String?) -> [String] {
+    guard let sport else { return [] }
+    return lookup(sport) ?? []
+  }
+
+  /// Sport-scoped normalization: expand abbreviations, collapse coarse buckets
+  /// (`Infielder`/`Outfielder`) to `Utility`, snap already-canonical values to
+  /// canonical casing, and PRESERVE unknown values (never drop). Collisions are
+  /// resolved by sport — `C` = Catcher (baseball) vs Center (basketball), `P` =
+  /// Pitcher (baseball) vs Punter (football).
+  static func normalize(sport: String?, _ value: String?) -> String? {
+    guard let raw = value?.trimmingCharacters(in: .whitespaces), !raw.isEmpty else { return value }
+
+    if coarseBuckets.contains(raw.lowercased()) { return "Utility" }
+
+    let sportKey = sport?.lowercased() ?? ""
+    if let expanded = abbreviations[sportKey]?[raw.uppercased()] { return expanded }
+
+    if let match = lookup(sport ?? "")?.first(where: { $0.caseInsensitiveCompare(raw) == .orderedSame }) {
+      return match
+    }
+
+    return raw
+  }
+
+  // MARK: - Private
+
+  private static let coarseBuckets: Set<String> = ["infielder", "outfielder", "infield", "outfield", "if", "of"]
+
+  private static func lookup(_ sport: String) -> [String]? {
+    bySport.first { $0.key.caseInsensitiveCompare(sport) == .orderedSame }?.value
+  }
+
+  /// Per-sport abbreviation → canonical, keyed by lowercased sport then
+  /// uppercased token. Per-sport scoping resolves `C`/`P` collisions.
+  private static let abbreviations: [String: [String: String]] = [
+    "baseball": baseballAbbrev,
+    "softball": baseballAbbrev,
+    "basketball": ["PG": "Point Guard", "SG": "Shooting Guard", "SF": "Small Forward",
+                   "PF": "Power Forward", "C": "Center"],
+    "football": ["QB": "Quarterback", "RB": "Running Back", "WR": "Wide Receiver",
+                 "TE": "Tight End", "OL": "Offensive Line", "DL": "Defensive Line",
+                 "LB": "Linebacker", "DB": "Defensive Back", "K": "Kicker", "P": "Punter"],
+    "soccer": ["GK": "Goalkeeper", "DEF": "Defender", "MID": "Midfielder", "FWD": "Forward"]
+  ]
+
+  private static let baseballAbbrev: [String: String] = [
+    "P": "Pitcher", "C": "Catcher", "1B": "First Base", "2B": "Second Base", "3B": "Third Base",
+    "SS": "Shortstop", "LF": "Left Field", "CF": "Center Field", "RF": "Right Field",
+    "DH": "Designated Hitter", "UTIL": "Utility"
+  ]
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Family/Utilities/FamilyConstants.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Family/Utilities/FamilyConstants.swift
@@ -36,30 +36,4 @@ enum FamilyConstants {
       "Other"
     ]
   }
-
-  /// Positions list for parent onboarding (common across sports; replicate from web as needed).
-  enum Positions {
-    static let all: [String] = [
-      "Pitcher",
-      "Catcher",
-      "Infielder",
-      "Outfielder",
-      "Guard",
-      "Forward",
-      "Center",
-      "Quarterback",
-      "Running Back",
-      "Wide Receiver",
-      "Linebacker",
-      "Defensive Back",
-      "Lineman",
-      "Midfielder",
-      "Defender",
-      "Goalkeeper",
-      "Setter",
-      "Outside Hitter",
-      "Libero",
-      "Other"
-    ]
-  }
 }

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Onboarding/Utilities/OnboardingConstants.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Onboarding/Utilities/OnboardingConstants.swift
@@ -10,26 +10,10 @@ enum OnboardingConstants {
     "Field Hockey", "Ice Hockey", "Wrestling", "Rowing", "Water Polo"
   ]
 
-  static let sportPositions: [String: [String]] = [
-    "Baseball": ["Pitcher", "Catcher", "Infielder", "Outfielder", "Designated Hitter"],
-    "Basketball": ["Point Guard", "Shooting Guard", "Small Forward", "Power Forward", "Center"],
-    "Football": ["Quarterback", "Running Back", "Wide Receiver", "Tight End", "Offensive Line", "Linebacker", "Defensive Back", "Defensive Line"],
-    "Soccer": ["Goalkeeper", "Defender", "Midfielder", "Forward"],
-    "Volleyball": ["Outside Hitter", "Middle Blocker", "Setter", "Libero", "Opposite Hitter"],
-    "Softball": ["Pitcher", "Catcher", "Infielder", "Outfielder", "Designated Hitter"],
-    "Track & Field": ["Sprinter", "Distance Runner", "Jumper", "Thrower"],
-    "Swimming": ["Freestyle", "Backstroke", "Breaststroke", "Butterfly", "Individual Medley"],
-    "Cross Country": ["Runner"],
-    "Tennis": ["Singles", "Doubles"],
-    "Golf": ["Golfer"],
-    "Lacrosse": ["Attackman", "Midfielder", "Defenseman", "Goalie"],
-    "Field Hockey": ["Forward", "Midfielder", "Defender", "Goalkeeper"],
-    "Ice Hockey": ["Forward", "Defenseman", "Goalie"],
-    "Wrestling": ["Wrestler"],
-    "Rowing": ["Rower"],
-    "Water Polo": ["Field Player", "Goalkeeper"],
-    "Other": ["Other"]
-  ]
+  /// Canonical sport-scoped positions (mirrors web) plus an "Other" fallback for
+  /// the "Other" sport option. See `CanonicalPositions`.
+  static let sportPositions: [String: [String]] =
+    CanonicalPositions.bySport.merging(["Other": ["Other"]]) { current, _ in current }
 
   static var graduationYears: [Int] {
     GradeLevelHelper.allowedGraduationYears

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -67,7 +67,9 @@ final class OnboardingViewModel {
     guard let existing: PlayerDetails = try? await preferenceService.fetchPreferences(category: .player) else { return }
     if let year = existing.graduationYear { graduationYear = year }
     if let sport = existing.primarySport, !sport.isEmpty { primarySport = sport }
-    if let position = existing.primaryPosition, !position.isEmpty { primaryPosition = position }
+    if let position = existing.primaryPosition, !position.isEmpty {
+      primaryPosition = CanonicalPositions.normalize(sport: existing.primarySport, position) ?? position
+    }
     logger.debug("Pre-filled onboarding from existing player preferences")
   }
 

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/CoreCoursesEditor.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/CoreCoursesEditor.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+struct CoreCoursesEditor: View {
+    @Binding var courses: [String]
+    let isDisabled: Bool
+    @State private var newCourse: String = ""
+
+    static let maxCourses = 20
+    static let maxLength = 60
+
+    /// Returns the normalized course to append, or nil if it must be rejected.
+    static func normalizedToAdd(_ raw: String, existing: [String]) -> String? {
+        let trimmed = String(raw.trimmingCharacters(in: .whitespacesAndNewlines).prefix(maxLength))
+        guard !trimmed.isEmpty else { return nil }
+        guard existing.count < maxCourses else { return nil }
+        guard !existing.contains(trimmed) else { return nil }
+        return trimmed
+    }
+
+    private func add() {
+        guard let course = Self.normalizedToAdd(newCourse, existing: courses) else { return }
+        courses.append(course)
+        newCourse = ""
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("AP, honors, or notable courses for your recruiting profile.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if !courses.isEmpty {
+                WrapLayout(spacing: 8) {
+                    ForEach(courses, id: \.self) { course in
+                        HStack(spacing: 6) {
+                            Text(course).font(.subheadline)
+                            if !isDisabled {
+                                Button {
+                                    courses.removeAll { $0 == course }
+                                } label: {
+                                    Image(systemName: "xmark").font(.caption2.weight(.bold))
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Remove \(course)")
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.accentColor.opacity(0.12))
+                        .foregroundStyle(Color.accentColor)
+                        .clipShape(Capsule())
+                    }
+                }
+            }
+
+            if !isDisabled && courses.count < Self.maxCourses {
+                HStack(spacing: 8) {
+                    TextField("e.g., AP Chemistry", text: $newCourse)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit(add)
+                    Button("Add", action: add)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(newCourse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            } else if courses.count >= Self.maxCourses {
+                Text("Maximum 20 courses added.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+    }
+}
+
+private struct WrapLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0, rowHeight: CGFloat = 0, totalHeight: CGFloat = 0, maxRowWidth: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if rowWidth + size.width > maxWidth, rowWidth > 0 {
+                totalHeight += rowHeight + spacing
+                maxRowWidth = max(maxRowWidth, rowWidth - spacing)
+                rowWidth = 0; rowHeight = 0
+            }
+            rowWidth += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        totalHeight += rowHeight
+        maxRowWidth = max(maxRowWidth, rowWidth - spacing)
+        return CGSize(width: min(maxWidth, maxRowWidth), height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX, y = bounds.minY, rowHeight: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX, x > bounds.minX {
+                x = bounds.minX; y += rowHeight + spacing; rowHeight = 0
+            }
+            sub.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/PositionChipsView.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/PositionChipsView.swift
@@ -6,20 +6,7 @@ struct PositionChipsView: View {
     let isDisabled: Bool
 
     private var availablePositions: [String] {
-        switch sport?.lowercased() {
-        case "baseball", "softball":
-            return ["Pitcher", "Catcher", "First Base", "Second Base", "Third Base",
-                    "Shortstop", "Left Field", "Center Field", "Right Field", "Designated Hitter"]
-        case "basketball":
-            return ["Point Guard", "Shooting Guard", "Small Forward", "Power Forward", "Center"]
-        case "football":
-            return ["Quarterback", "Running Back", "Wide Receiver", "Tight End", "Offensive Line",
-                    "Defensive Line", "Linebacker", "Cornerback", "Safety", "Kicker", "Punter"]
-        case "soccer":
-            return ["Goalkeeper", "Defender", "Midfielder", "Forward", "Winger", "Sweeper"]
-        default:
-            return []
-        }
+        CanonicalPositions.positions(for: sport)
     }
 
     var body: some View {

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift
@@ -39,6 +39,12 @@ struct PlayerDetails: Codable, Equatable, Sendable {
   var allowSharePhone: Bool?
   var allowShareEmail: Bool?
 
+  // College Preferences (fit analysis) — canonical enums shared with web:
+  // campusSizePreference: "small" | "medium" | "large"
+  // costSensitivity: "high" | "medium" | "low"
+  var campusSizePreference: String?
+  var costSensitivity: String?
+
   // School Info
   var schoolName: String?
   var schoolAddress: String?
@@ -123,6 +129,8 @@ struct PlayerDetails: Codable, Equatable, Sendable {
     case email
     case allowSharePhone = "allow_share_phone"
     case allowShareEmail = "allow_share_email"
+    case campusSizePreference = "campus_size_preference"
+    case costSensitivity = "cost_sensitivity"
     case schoolName = "school_name"
     case schoolAddress = "school_address"
     case schoolCity = "school_city"

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift
@@ -21,6 +21,7 @@ struct PlayerDetails: Codable, Equatable, Sendable {
   var gpa: Double? // 0.0-5.0
   var satScore: Int? // 400-1600
   var actScore: Int? // 1-36
+  var coreCourses: [String]? // AP/honors/notable courses (max 20)
 
   // External IDs
   var ncaaId: String?
@@ -118,6 +119,7 @@ struct PlayerDetails: Codable, Equatable, Sendable {
     case gpa
     case satScore = "sat_score"
     case actScore = "act_score"
+    case coreCourses = "core_courses"
     case ncaaId = "ncaa_id"
     case perfectGameId = "perfect_game_id"
     case prepBaseballId = "prep_baseball_id"

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
@@ -114,6 +114,7 @@ final class PlayerDetailsViewModel {
         do {
             if let savedDetails: PlayerDetails = try await preferenceService.fetchPreferences(category: .player, userId: targetUserId) {
                 details = savedDetails
+                normalizePositions()
                 logger.info("Loaded existing player details")
             } else {
                 details = .default
@@ -267,11 +268,15 @@ final class PlayerDetailsViewModel {
         markChanged()
     }
 
+    /// Snap stored positions to the canonical, sport-scoped vocabulary (expands
+    /// abbreviations, collapses legacy "Infielder"/"Outfielder" → "Utility",
+    /// preserves unknowns). Runs on load and before save so legacy values
+    /// round-trip identically to web.
     func normalizePositions() {
-        details.positions = details.positions?.map { pos in
-            pos.split(separator: " ")
-                .map { $0.prefix(1).uppercased() + $0.dropFirst().lowercased() }
-                .joined(separator: " ")
+        let sport = details.primarySport
+        details.primaryPosition = CanonicalPositions.normalize(sport: sport, details.primaryPosition)
+        details.positions = details.positions?.compactMap {
+            CanonicalPositions.normalize(sport: sport, $0)
         }
     }
 

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/ViewModels/PlayerDetailsViewModel.swift
@@ -47,6 +47,10 @@ final class PlayerDetailsViewModel {
     /// The athlete whose video/location we score: the explicit target, else the
     /// signed-in user (a player viewing their own profile).
     private var effectiveUserId: String? { targetUserId ?? authManager.user?.id }
+
+    /// Canonical athlete id for child editors (e.g. Video Links). Empty when no
+    /// user is resolvable yet — the editor treats that as an empty, read-only list.
+    var athleteUserId: String { effectiveUserId ?? "" }
     @ObservationIgnored nonisolated(unsafe) private var pendingAutoSave: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var pendingStatusReset: Task<Void, Never>?
 

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AcademicsSocialTab.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AcademicsSocialTab.swift
@@ -12,7 +12,7 @@ struct AcademicsSocialTab: View {
                         divider
                         textRow(String(localized: "City"), keyPath: \.schoolCity)
                         divider
-                        textRow(String(localized: "State"), keyPath: \.schoolState)
+                        textRow(String(localized: "State"), keyPath: \.schoolState, autocapitalization: .characters)
                     }
                 }
 
@@ -50,7 +50,8 @@ struct AcademicsSocialTab: View {
         _ label: String,
         placeholder: String = "",
         keyPath: WritableKeyPath<PlayerDetails, String?>,
-        keyboardType: UIKeyboardType = .default
+        keyboardType: UIKeyboardType = .default,
+        autocapitalization: TextInputAutocapitalization = .sentences
     ) -> some View {
         HStack {
             Text(label).font(.body)
@@ -65,8 +66,7 @@ struct AcademicsSocialTab: View {
             .multilineTextAlignment(.trailing)
             .foregroundStyle(.secondary)
             .keyboardType(keyboardType)
-            .textInputAutocapitalization(.never)
-            .autocorrectionDisabled()
+            .textInputAutocapitalization(autocapitalization)
             .disabled(viewModel.isReadOnly)
         }
         .padding(.horizontal)

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AcademicsSocialTab.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AcademicsSocialTab.swift
@@ -6,6 +6,16 @@ struct AcademicsSocialTab: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
+                cardSection(String(localized: "High School")) {
+                    VStack(spacing: 0) {
+                        textRow(String(localized: "High School"), keyPath: \.highSchool)
+                        divider
+                        textRow(String(localized: "City"), keyPath: \.schoolCity)
+                        divider
+                        textRow(String(localized: "State"), keyPath: \.schoolState)
+                    }
+                }
+
                 cardSection(String(localized: "Academics")) {
                     VStack(spacing: 0) {
                         numericRow(String(localized: "GPA"), keyPath: \.gpa)
@@ -16,41 +26,17 @@ struct AcademicsSocialTab: View {
                     }
                 }
 
-                cardSection(String(localized: "Social Media")) {
-                    VStack(spacing: 0) {
-                        textRow(
-                            String(localized: "Twitter"),
-                            placeholder: String(localized: "@username"),
-                            keyPath: \.twitterHandle
-                        )
-                        divider
-                        textRow(
-                            String(localized: "Instagram"),
-                            placeholder: String(localized: "@username"),
-                            keyPath: \.instagramHandle
-                        )
-                        divider
-                        textRow(
-                            String(localized: "TikTok"),
-                            placeholder: String(localized: "@username"),
-                            keyPath: \.tiktokHandle
-                        )
-                        divider
-                        textRow(
-                            String(localized: "Facebook URL"),
-                            placeholder: String(localized: "https://..."),
-                            keyPath: \.facebookUrl,
-                            keyboardType: .URL
-                        )
-                    }
-                }
-
-                cardSection(String(localized: "Privacy")) {
-                    VStack(spacing: 0) {
-                        toggleRow(String(localized: "Share phone with coaches"), keyPath: \.allowSharePhone)
-                        divider
-                        toggleRow(String(localized: "Share email with coaches"), keyPath: \.allowShareEmail)
-                    }
+                cardSection(String(localized: "Core Courses")) {
+                    CoreCoursesEditor(
+                        courses: Binding(
+                            get: { viewModel.details.coreCourses ?? [] },
+                            set: {
+                                viewModel.details.coreCourses = $0.isEmpty ? nil : $0
+                                viewModel.markChanged()
+                            }
+                        ),
+                        isDisabled: viewModel.isReadOnly
+                    )
                 }
             }
             .padding()
@@ -125,19 +111,6 @@ struct AcademicsSocialTab: View {
             .disabled(viewModel.isReadOnly)
             .frame(width: 80)
         }
-        .padding(.horizontal)
-        .padding(.vertical, 12)
-    }
-
-    private func toggleRow(_ label: String, keyPath: WritableKeyPath<PlayerDetails, Bool?>) -> some View {
-        Toggle(label, isOn: Binding(
-            get: { viewModel.details[keyPath: keyPath] ?? false },
-            set: {
-                viewModel.details[keyPath: keyPath] = $0
-                viewModel.markChanged()
-            }
-        ))
-        .disabled(viewModel.isReadOnly)
         .padding(.horizontal)
         .padding(.vertical, 12)
     }

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AthleticsTab.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AthleticsTab.swift
@@ -6,11 +6,11 @@ struct AthleticsTab: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                cardSection(String(localized: "Physical Stats")) {
+                cardSection(String(localized: "Physical Profile")) {
                     physicalStatsCard
                 }
 
-                cardSection(String(localized: "Positions")) {
+                cardSection(String(localized: "Positions You Play")) {
                     PositionChipsView(
                         sport: viewModel.details.primarySport,
                         selectedPositions: Binding(
@@ -25,16 +25,12 @@ struct AthleticsTab: View {
                     .padding()
                 }
 
-                if viewModel.isBaseballOrSoftball {
-                    cardSection(String(localized: "Baseball / Softball")) {
-                        baseballCard
-                    }
-                    .animation(.easeInOut, value: viewModel.isBaseballOrSoftball)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                cardSection(String(localized: "Recruiting Database IDs")) {
+                    externalIdsCard
                 }
 
-                cardSection(String(localized: "External IDs")) {
-                    externalIdsCard
+                cardSection(String(localized: "Video Links")) {
+                    videoLinksRow
                 }
             }
             .padding()
@@ -50,7 +46,41 @@ struct AthleticsTab: View {
             heightRow
             divider
             weightRow
+            if viewModel.isBaseballOrSoftball {
+                divider
+                choiceRow(
+                    String(localized: "Bats"),
+                    options: [
+                        ("R", String(localized: "Right")),
+                        ("L", String(localized: "Left")),
+                        ("S", String(localized: "Switch"))
+                    ],
+                    selection: Binding(
+                        get: { viewModel.details.bats },
+                        set: {
+                            viewModel.details.bats = $0
+                            viewModel.markChanged()
+                        }
+                    )
+                )
+                divider
+                choiceRow(
+                    String(localized: "Throws"),
+                    options: [
+                        ("R", String(localized: "Right")),
+                        ("L", String(localized: "Left"))
+                    ],
+                    selection: Binding(
+                        get: { viewModel.details.throws_ },
+                        set: {
+                            viewModel.details.throws_ = $0
+                            viewModel.markChanged()
+                        }
+                    )
+                )
+            }
         }
+        .animation(.easeInOut, value: viewModel.isBaseballOrSoftball)
     }
 
     @ViewBuilder
@@ -113,44 +143,37 @@ struct AthleticsTab: View {
         .padding(.vertical, 12)
     }
 
-    // MARK: - Baseball Card
+    // MARK: - Video Links
 
+    /// Row pushing the shared Video Links editor. The editor owns its own toolbar
+    /// "Add" button, so it must be pushed rather than embedded inline.
     @ViewBuilder
-    private var baseballCard: some View {
-        VStack(spacing: 0) {
-            segmentedRow(
-                String(localized: "Bats"),
-                selection: Binding<String>(
-                    get: { viewModel.details.bats ?? "" },
-                    set: {
-                        viewModel.details.bats = $0.isEmpty ? nil : $0
-                        viewModel.markChanged()
-                    }
-                ),
-                tags: [
-                    ("", String(localized: "–")),
-                    ("R", String(localized: "Right (R)")),
-                    ("L", String(localized: "Left (L)")),
-                    ("S", String(localized: "Switch (S)"))
-                ]
+    private var videoLinksRow: some View {
+        NavigationLink {
+            VideoLinksEditorView(
+                athleteUserId: viewModel.athleteUserId,
+                familyUnitId: FamilyManager.shared.currentMember?.familyUnitId,
+                isReadOnly: viewModel.isReadOnly
             )
-            divider
-            segmentedRow(
-                String(localized: "Throws"),
-                selection: Binding<String>(
-                    get: { viewModel.details.throws_ ?? "" },
-                    set: {
-                        viewModel.details.throws_ = $0.isEmpty ? nil : $0
-                        viewModel.markChanged()
-                    }
-                ),
-                tags: [
-                    ("", String(localized: "–")),
-                    ("R", String(localized: "Right (R)")),
-                    ("L", String(localized: "Left (L)"))
-                ]
-            )
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Video Links")
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                    Text("Hudl, YouTube, or Vimeo highlight reels")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding()
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
     }
 
     // MARK: - External IDs Card
@@ -189,18 +212,37 @@ struct AthleticsTab: View {
         .padding(.vertical, 12)
     }
 
-    private func segmentedRow<Tag: Hashable>(_ label: String, selection: Binding<Tag>, tags: [(Tag, String)]) -> some View {
-        HStack {
-            Text(label).font(.body)
-            Spacer()
-            Picker(label, selection: selection) {
-                ForEach(Array(tags.enumerated()), id: \.offset) { _, pair in
-                    Text(pair.1).tag(pair.0)
+    /// Web-parity segmented selector: selected option gets a filled accent highlight
+    /// (the system `.segmented` style rendered selection too subtly to read).
+    private func choiceRow(
+        _ label: String,
+        options: [(value: String, label: String)],
+        selection: Binding<String?>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 8) {
+                ForEach(options, id: \.value) { opt in
+                    let isSelected = selection.wrappedValue == opt.value
+                    Button {
+                        selection.wrappedValue = opt.value
+                    } label: {
+                        Text(opt.label)
+                            .font(.subheadline.weight(.semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                            .background(isSelected ? Color.accentColor : Color(.tertiarySystemFill))
+                            .foregroundStyle(isSelected ? Color.white : Color.primary)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(viewModel.isReadOnly)
+                    .accessibilityLabel("\(label): \(opt.label)")
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                 }
             }
-            .pickerStyle(.segmented)
-            .fixedSize()
-            .disabled(viewModel.isReadOnly)
         }
         .padding(.horizontal)
         .padding(.vertical, 12)

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift
@@ -25,6 +25,14 @@ struct BasicsTab: View {
                     basicInfoCard
                 }
 
+                cardSection(String(localized: "Contact")) {
+                    contactCard
+                }
+
+                cardSection(String(localized: "Social")) {
+                    socialCard
+                }
+
                 cardSection(String(localized: "College Preferences")) {
                     collegePrefsCard
                 }
@@ -112,13 +120,79 @@ struct BasicsTab: View {
             gradYearRow
             divider
             primarySportRow
-            divider
-            textRow(String(localized: "High School"), keyPath: \.highSchool)
-            divider
-            textRow(String(localized: "City"), keyPath: \.schoolCity)
-            divider
-            textRow(String(localized: "State"), keyPath: \.schoolState, autocapitalization: .characters)
         }
+    }
+
+    // MARK: - Contact Card
+
+    @ViewBuilder
+    private var contactCard: some View {
+        VStack(spacing: 0) {
+            handleRow(String(localized: "Phone"), placeholder: String(localized: "Phone"),
+                      keyPath: \.phone, keyboardType: .phonePad)
+            divider
+            handleRow(String(localized: "Email"), placeholder: String(localized: "Email"),
+                      keyPath: \.email, keyboardType: .emailAddress)
+            divider
+            toggleRow(String(localized: "Share phone with coaches"), keyPath: \.allowSharePhone)
+            divider
+            toggleRow(String(localized: "Share email with coaches"), keyPath: \.allowShareEmail)
+        }
+    }
+
+    // MARK: - Social Card
+
+    @ViewBuilder
+    private var socialCard: some View {
+        VStack(spacing: 0) {
+            handleRow(String(localized: "Twitter"), placeholder: String(localized: "@username"), keyPath: \.twitterHandle)
+            divider
+            handleRow(String(localized: "Instagram"), placeholder: String(localized: "@username"), keyPath: \.instagramHandle)
+            divider
+            handleRow(String(localized: "TikTok"), placeholder: String(localized: "@username"), keyPath: \.tiktokHandle)
+            divider
+            handleRow(String(localized: "Facebook URL"), placeholder: String(localized: "https://..."), keyPath: \.facebookUrl, keyboardType: .URL)
+        }
+    }
+
+    private func handleRow(
+        _ label: String,
+        placeholder: String = "",
+        keyPath: WritableKeyPath<PlayerDetails, String?>,
+        keyboardType: UIKeyboardType = .default
+    ) -> some View {
+        HStack {
+            Text(label).font(.body)
+            Spacer()
+            TextField(placeholder.isEmpty ? label : placeholder, text: Binding(
+                get: { viewModel.details[keyPath: keyPath] ?? "" },
+                set: {
+                    viewModel.details[keyPath: keyPath] = $0.isEmpty ? nil : $0
+                    viewModel.markChanged()
+                }
+            ))
+            .multilineTextAlignment(.trailing)
+            .foregroundStyle(.secondary)
+            .keyboardType(keyboardType)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .disabled(viewModel.isReadOnly)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+    }
+
+    private func toggleRow(_ label: String, keyPath: WritableKeyPath<PlayerDetails, Bool?>) -> some View {
+        Toggle(label, isOn: Binding(
+            get: { viewModel.details[keyPath: keyPath] ?? false },
+            set: {
+                viewModel.details[keyPath: keyPath] = $0
+                viewModel.markChanged()
+            }
+        ))
+        .disabled(viewModel.isReadOnly)
+        .padding(.horizontal)
+        .padding(.vertical, 12)
     }
 
     // MARK: - College Preferences Card
@@ -226,29 +300,6 @@ struct BasicsTab: View {
                     Text(sport).tag(sport)
                 }
             }
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 12)
-    }
-
-    private func textRow(
-        _ label: String,
-        keyPath: WritableKeyPath<PlayerDetails, String?>,
-        autocapitalization: TextInputAutocapitalization = .sentences
-    ) -> some View {
-        HStack {
-            Text(label)
-            Spacer()
-            TextField(label, text: Binding(
-                get: { viewModel.details[keyPath: keyPath] ?? "" },
-                set: {
-                    viewModel.details[keyPath: keyPath] = $0.isEmpty ? nil : $0
-                    viewModel.markChanged()
-                }
-            ))
-            .multilineTextAlignment(.trailing)
-            .foregroundStyle(.secondary)
-            .textInputAutocapitalization(autocapitalization)
         }
         .padding(.horizontal)
         .padding(.vertical, 12)

--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift
@@ -24,6 +24,10 @@ struct BasicsTab: View {
                 cardSection(String(localized: "Basic Information")) {
                     basicInfoCard
                 }
+
+                cardSection(String(localized: "College Preferences")) {
+                    collegePrefsCard
+                }
             }
             .padding()
         }
@@ -46,50 +50,58 @@ struct BasicsTab: View {
 
     @ViewBuilder
     private var photoCard: some View {
-        VStack(spacing: 16) {
-            if let image = viewModel.profileImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: 120, height: 120)
-                    .clipShape(Circle())
-            } else if let urlString = viewModel.photoUrl, let url = URL(string: urlString) {
-                AsyncImage(url: url) { phase in
-                    switch phase {
-                    case .success(let image):
-                        image.resizable().scaledToFill()
-                    default:
-                        Image(systemName: "person.crop.circle.fill")
-                            .resizable().scaledToFit().foregroundStyle(.tertiary)
-                    }
-                }
-                .frame(width: 120, height: 120)
-                .clipShape(Circle())
-            } else {
-                Image(systemName: "person.crop.circle.fill")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 120, height: 120)
-                    .foregroundStyle(.tertiary)
-            }
+        HStack(alignment: .center, spacing: 20) {
+            photoImage
 
-            PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
-                Label("Choose Photo", systemImage: "photo")
-            }
-            .accessibilityLabel(String(localized: "Choose profile photo"))
-            .disabled(viewModel.isReadOnly)
-
-            if viewModel.profileImage != nil || viewModel.photoUrl != nil {
-                Button(role: .destructive) {
-                    viewModel.showDeletePhotoConfirmation = true
-                } label: {
-                    Text("Delete Photo")
+            VStack(alignment: .leading, spacing: 16) {
+                PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                    Label("Choose Photo", systemImage: "photo")
                 }
+                .accessibilityLabel(String(localized: "Choose profile photo"))
                 .disabled(viewModel.isReadOnly)
+
+                if viewModel.profileImage != nil || viewModel.photoUrl != nil {
+                    Button(role: .destructive) {
+                        viewModel.showDeletePhotoConfirmation = true
+                    } label: {
+                        Label("Delete Photo", systemImage: "trash")
+                    }
+                    .disabled(viewModel.isReadOnly)
+                }
             }
+
+            Spacer(minLength: 0)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 20)
+        .padding(.vertical, 16)
+    }
+
+    @ViewBuilder
+    private var photoImage: some View {
+        if let image = viewModel.profileImage {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 100, height: 100)
+                .clipShape(Circle())
+        } else if let urlString = viewModel.photoUrl, let url = URL(string: urlString) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image.resizable().scaledToFill()
+                default:
+                    Image(systemName: "person.crop.circle.fill")
+                        .resizable().scaledToFit().foregroundStyle(.tertiary)
+                }
+            }
+            .frame(width: 100, height: 100)
+            .clipShape(Circle())
+        } else {
+            Image(systemName: "person.crop.circle.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 100, height: 100)
+                .foregroundStyle(.tertiary)
+        }
     }
 
     // MARK: - Basic Info Card
@@ -107,6 +119,67 @@ struct BasicsTab: View {
             divider
             textRow(String(localized: "State"), keyPath: \.schoolState, autocapitalization: .characters)
         }
+    }
+
+    // MARK: - College Preferences Card
+
+    private let campusSizeOptions: [(value: String, label: String)] = [
+        ("small", "Small (<5K)"),
+        ("medium", "Mid (5K–25K)"),
+        ("large", "Large (25K+)")
+    ]
+
+    private let costSensitivityOptions: [(value: String, label: String)] = [
+        ("high", "High"),
+        ("medium", "Medium"),
+        ("low", "Low")
+    ]
+
+    @ViewBuilder
+    private var collegePrefsCard: some View {
+        VStack(spacing: 0) {
+            segmentedRow(
+                String(localized: "Campus Size Preference"),
+                options: campusSizeOptions,
+                keyPath: \.campusSizePreference
+            )
+            divider
+            segmentedRow(
+                String(localized: "Cost Sensitivity"),
+                options: costSensitivityOptions,
+                keyPath: \.costSensitivity
+            )
+        }
+    }
+
+    private func segmentedRow(
+        _ label: String,
+        options: [(value: String, label: String)],
+        keyPath: WritableKeyPath<PlayerDetails, String?>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label)
+            Picker(label, selection: Binding(
+                get: { viewModel.details[keyPath: keyPath] ?? "" },
+                set: {
+                    viewModel.details[keyPath: keyPath] = $0.isEmpty ? nil : $0
+                    viewModel.markChanged()
+                }
+            )) {
+                Text("—").tag("")
+                ForEach(options, id: \.value) { opt in
+                    Text(opt.label).tag(opt.value)
+                }
+            }
+            .pickerStyle(.segmented)
+            .disabled(viewModel.isReadOnly)
+
+            Text("Used for personal fit analysis")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
     }
 
     @ViewBuilder

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Core/Utilities/CanonicalPositionsTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Core/Utilities/CanonicalPositionsTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import TheRecruitingCompass
+
+final class CanonicalPositionsTests: XCTestCase {
+
+    // MARK: - positions(for:)
+
+    func testPositionsForSportIsCaseInsensitive() {
+        XCTAssertEqual(CanonicalPositions.positions(for: "baseball"),
+                       CanonicalPositions.positions(for: "Baseball"))
+    }
+
+    func testSoftballSharesBaseballPositions() {
+        XCTAssertEqual(CanonicalPositions.positions(for: "Softball"),
+                       CanonicalPositions.positions(for: "Baseball"))
+    }
+
+    func testNoPickerListsCoarseBuckets() {
+        for positions in CanonicalPositions.bySport.values {
+            for coarse in ["Infielder", "Outfielder", "Guard", "Lineman"] {
+                XCTAssertFalse(positions.contains(coarse), "Found coarse bucket \(coarse)")
+            }
+        }
+    }
+
+    func testUnknownSportReturnsEmpty() {
+        XCTAssertTrue(CanonicalPositions.positions(for: "Other").isEmpty)
+        XCTAssertTrue(CanonicalPositions.positions(for: nil).isEmpty)
+    }
+
+    // MARK: - normalize coarse buckets → Utility
+
+    func testInfielderCollapsesToUtility() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "Infielder"), "Utility")
+    }
+
+    func testOutfielderCollapsesToUtility() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "OF"), "Utility")
+    }
+
+    // MARK: - abbreviation expansion + sport-scoped collisions
+
+    func testBaseballCIsCatcher() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "C"), "Catcher")
+    }
+
+    func testBasketballCIsCenter() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Basketball", "C"), "Center")
+    }
+
+    func testBaseballPIsPitcher() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "P"), "Pitcher")
+    }
+
+    func testFootballPIsPunter() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Football", "P"), "Punter")
+    }
+
+    func testBaseballAbbreviationsExpand() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "SS"), "Shortstop")
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "1b"), "First Base")
+    }
+
+    // MARK: - canonical passthrough + preservation
+
+    func testAlreadyCanonicalSnapsToCanonicalCasing() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "shortstop"), "Shortstop")
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Basketball", "point guard"), "Point Guard")
+    }
+
+    func testUnknownValueIsPreserved() {
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "Designated Runner"),
+                       "Designated Runner")
+    }
+
+    func testNilAndEmptyPassThrough() {
+        XCTAssertNil(CanonicalPositions.normalize(sport: "Baseball", nil))
+        XCTAssertEqual(CanonicalPositions.normalize(sport: "Baseball", "   "), "   ")
+    }
+}

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/CoreCoursesLogicTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/CoreCoursesLogicTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import TheRecruitingCompass
+
+final class CoreCoursesLogicTests: XCTestCase {
+    func testTrimsAndAdds() {
+        XCTAssertEqual(CoreCoursesEditor.normalizedToAdd("  AP Chem  ", existing: []), "AP Chem")
+    }
+    func testRejectsBlank() {
+        XCTAssertNil(CoreCoursesEditor.normalizedToAdd("   ", existing: []))
+    }
+    func testRejectsDuplicate() {
+        XCTAssertNil(CoreCoursesEditor.normalizedToAdd("AP Chem", existing: ["AP Chem"]))
+    }
+    func testRejectsAtCap() {
+        let full = (1...20).map { "Course \($0)" }
+        XCTAssertNil(CoreCoursesEditor.normalizedToAdd("Extra", existing: full))
+    }
+    func testTruncatesToSixtyChars() {
+        let long = String(repeating: "x", count: 80)
+        XCTAssertEqual(CoreCoursesEditor.normalizedToAdd(long, existing: [])?.count, 60)
+    }
+}

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/PlayerDetailsCodableTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/PlayerDetailsCodableTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import TheRecruitingCompass
+
+final class PlayerDetailsCodableTests: XCTestCase {
+    func testCoreCoursesRoundTrips() throws {
+        let json = #"{"core_courses":["AP Chemistry","Honors English"]}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(PlayerDetails.self, from: json)
+        XCTAssertEqual(decoded.coreCourses, ["AP Chemistry", "Honors English"])
+
+        let reencoded = try JSONEncoder().encode(decoded)
+        let obj = try JSONSerialization.jsonObject(with: reencoded) as! [String: Any]
+        XCTAssertEqual(obj["core_courses"] as? [String], ["AP Chemistry", "Honors English"])
+    }
+}

--- a/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/ViewModels/PlayerDetailsViewModelTests.swift
+++ b/TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/ViewModels/PlayerDetailsViewModelTests.swift
@@ -423,11 +423,13 @@ final class PlayerDetailsViewModelTests: XCTestCase {
     XCTAssertEqual(viewModel.completenessScore, 0.25, accuracy: 0.0001)
   }
 
-  func testNormalizePositions_TitleCasesAll() {
+  func testNormalizePositions_SportScopedCanonicalization() {
     viewModel = PlayerDetailsViewModel(preferenceService: mockService, userRole: .player)
+    viewModel.details.primarySport = "Baseball"
     viewModel.details.positions = ["pitcher", "FIRST BASE", "outfielder"]
     viewModel.normalizePositions()
-    XCTAssertEqual(viewModel.details.positions, ["Pitcher", "First Base", "Outfielder"])
+    // Sport-scoped: canonical casing snap + coarse bucket ("outfielder") → Utility.
+    XCTAssertEqual(viewModel.details.positions, ["Pitcher", "First Base", "Utility"])
   }
 
   func testNormalizePositions_NilPositions_StaysNil() {

--- a/docs/superpowers/plans/2026-08-10-player-profile-tab-reorg.md
+++ b/docs/superpowers/plans/2026-08-10-player-profile-tab-reorg.md
@@ -1,0 +1,715 @@
+# Player Profile Tab Reorganization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Regroup Player Profile fields by purpose across iOS and web — Contact+Privacy+Social → Basics, High School → Academics, add `core_courses` + phone/email inputs to iOS, and collapse web's duplicate phone/email to one home.
+
+**Architecture:** Pure UI relocation of fields that already exist in the `user_preferences` player JSON blob. No DB/migration. iOS: one new model field (`coreCourses`) + view moves across three tab files. Web: move DOM blocks between two tab components + rethread props from `player-details.vue`, rename one tab label.
+
+**Tech Stack:** iOS — SwiftUI, `@Observable` MVVM, XCTest. Web — Nuxt 3 / Vue 3 `<script setup>`, Vitest + Vue Test Utils.
+
+## Global Constraints
+
+- No database schema or migration change. Every field keeps its existing JSON key in `user_preferences.data` (category `player`).
+- Field JSON keys (verbatim): `phone`, `email`, `allow_share_phone`, `allow_share_email`, `core_courses`, `high_school`, `school_city`, `school_state`, `twitter_handle`, `instagram_handle`, `tiktok_handle`, `facebook_url`, `campus_size_preference`, `cost_sensitivity`.
+- Core Courses rules (both platforms): max 20 entries; max 60 chars each; trim whitespace; no duplicates; Return/Enter adds; read-only role cannot add/remove.
+- iOS builds must pass `xcodebuild build -scheme TheRecruitingCompass -destination 'platform=iOS Simulator,name=iPhone 17'` clean (run from `TheRecruitingCompass/`). Trust exit code, not a grep.
+- iOS paths are double-nested: `TheRecruitingCompass/TheRecruitingCompass/...`.
+- iOS Repo currently on branch `feat/player-basics-college-prefs`; keep committing there.
+- Campus size / cost sensitivity stay in Basics. Athletics, History, Public Profile tabs unchanged. Recruiting DB IDs stay in Athletics.
+- iOS `AcademicsSocialTab.swift` keeps its filename (avoids xcodeproj churn); only its content changes.
+- Web tab `id` stays `academics`; only the display `name` changes.
+
+---
+
+## Phase A — iOS
+
+### Task A1: Add `coreCourses` to the model
+
+**Files:**
+- Modify: `TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift`
+- Test: `TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/PlayerDetailsCodableTests.swift` (create if absent; otherwise add to the existing PlayerDetails test file)
+
+**Interfaces:**
+- Produces: `PlayerDetails.coreCourses: [String]?` mapped to JSON key `core_courses`.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import XCTest
+@testable import TheRecruitingCompass
+
+final class PlayerDetailsCodableTests: XCTestCase {
+    func testCoreCoursesRoundTrips() throws {
+        let json = #"{"core_courses":["AP Chemistry","Honors English"]}"#.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(PlayerDetails.self, from: json)
+        XCTAssertEqual(decoded.coreCourses, ["AP Chemistry", "Honors English"])
+
+        let reencoded = try JSONEncoder().encode(decoded)
+        let obj = try JSONSerialization.jsonObject(with: reencoded) as! [String: Any]
+        XCTAssertEqual(obj["core_courses"] as? [String], ["AP Chemistry", "Honors English"])
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run from `TheRecruitingCompass/`:
+`xcodebuild test -scheme TheRecruitingCompass -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:TheRecruitingCompassTests/PlayerDetailsCodableTests`
+Expected: FAIL — `coreCourses` is not a member of `PlayerDetails`.
+
+- [ ] **Step 3: Add the field + coding key**
+
+In `PlayerDetails.swift`, add near the Academics group:
+
+```swift
+  // Academics
+  var gpa: Double? // 0.0-5.0
+  var satScore: Int? // 400-1600
+  var actScore: Int? // 1-36
+  var coreCourses: [String]? // AP/honors/notable courses (max 20)
+```
+
+Add to `CodingKeys`:
+
+```swift
+    case actScore = "act_score"
+    case coreCourses = "core_courses"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the same command from Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Models/PlayerDetails.swift TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/PlayerDetailsCodableTests.swift
+git commit -m "feat(profile): add coreCourses to PlayerDetails model"
+```
+
+---
+
+### Task A2: Core Courses chip editor component
+
+**Files:**
+- Create: `TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/CoreCoursesEditor.swift`
+- Test: `TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/CoreCoursesLogicTests.swift`
+
+**Interfaces:**
+- Consumes: nothing from prior tasks except `PlayerDetails.coreCourses` (A1).
+- Produces: `struct CoreCoursesEditor: View` with `init(courses: Binding<[String]>, isDisabled: Bool)`. Pure add/remove helpers `CoreCoursesEditor.normalizedToAdd(_:existing:) -> String?` (static, testable) returning the trimmed course to append or `nil` if invalid/duplicate/at-cap.
+
+The static helper isolates the rules from SwiftUI so it is unit-testable without a host.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import XCTest
+@testable import TheRecruitingCompass
+
+final class CoreCoursesLogicTests: XCTestCase {
+    func testTrimsAndAdds() {
+        XCTAssertEqual(CoreCoursesEditor.normalizedToAdd("  AP Chem  ", existing: []), "AP Chem")
+    }
+    func testRejectsBlank() {
+        XCTAssertNil(CoreCoursesEditor.normalizedToAdd("   ", existing: []))
+    }
+    func testRejectsDuplicate() {
+        XCTAssertNil(CoreCoursesEditor.normalizedToAdd("AP Chem", existing: ["AP Chem"]))
+    }
+    func testRejectsAtCap() {
+        let full = (1...20).map { "Course \($0)" }
+        XCTAssertNil(CoreCoursesEditor.normalizedToAdd("Extra", existing: full))
+    }
+    func testTruncatesToSixtyChars() {
+        let long = String(repeating: "x", count: 80)
+        XCTAssertEqual(CoreCoursesEditor.normalizedToAdd(long, existing: [])?.count, 60)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `xcodebuild test -scheme TheRecruitingCompass -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:TheRecruitingCompassTests/CoreCoursesLogicTests`
+Expected: FAIL — `CoreCoursesEditor` not found.
+
+- [ ] **Step 3: Implement the component**
+
+```swift
+import SwiftUI
+
+struct CoreCoursesEditor: View {
+    @Binding var courses: [String]
+    let isDisabled: Bool
+    @State private var newCourse: String = ""
+
+    static let maxCourses = 20
+    static let maxLength = 60
+
+    /// Returns the normalized course to append, or nil if it must be rejected.
+    static func normalizedToAdd(_ raw: String, existing: [String]) -> String? {
+        let trimmed = String(raw.trimmingCharacters(in: .whitespacesAndNewlines).prefix(maxLength))
+        guard !trimmed.isEmpty else { return nil }
+        guard existing.count < maxCourses else { return nil }
+        guard !existing.contains(trimmed) else { return nil }
+        return trimmed
+    }
+
+    private func add() {
+        guard let course = Self.normalizedToAdd(newCourse, existing: courses) else { return }
+        courses.append(course)
+        newCourse = ""
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("AP, honors, or notable courses for your recruiting profile.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if !courses.isEmpty {
+                FlowChips(courses: $courses, isDisabled: isDisabled)
+            }
+
+            if !isDisabled && courses.count < Self.maxCourses {
+                HStack(spacing: 8) {
+                    TextField("e.g., AP Chemistry", text: $newCourse)
+                        .textFieldStyle(.roundedBorder)
+                        .onSubmit(add)
+                    Button("Add", action: add)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(newCourse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            } else if courses.count >= Self.maxCourses {
+                Text("Maximum 20 courses added.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+    }
+}
+
+private struct FlowChips: View {
+    @Binding var courses: [String]
+    let isDisabled: Bool
+
+    var body: some View {
+        // Simple wrapping layout via SwiftUI's native flow (iOS 16+: use a lazy grid fallback).
+        FlexibleWrap(items: courses) { course in
+            HStack(spacing: 6) {
+                Text(course).font(.subheadline)
+                if !isDisabled {
+                    Button {
+                        courses.removeAll { $0 == course }
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.caption2.weight(.bold))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Remove \(course)")
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color.accentColor.opacity(0.12))
+            .foregroundStyle(Color.accentColor)
+            .clipShape(Capsule())
+        }
+    }
+}
+```
+
+Add a minimal wrapping container in the same file (SwiftUI has no built-in flow layout pre-`Layout`; use the `Layout` protocol, iOS 16+):
+
+```swift
+private struct FlexibleWrap<Item: Hashable, Content: View>: View {
+    let items: [Item]
+    @ViewBuilder let content: (Item) -> Content
+
+    var body: some View {
+        WrapLayout(spacing: 8) {
+            ForEach(items, id: \.self) { content($0) }
+        }
+    }
+}
+
+private struct WrapLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var rowWidth: CGFloat = 0, rowHeight: CGFloat = 0, totalHeight: CGFloat = 0, maxRowWidth: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if rowWidth + size.width > maxWidth, rowWidth > 0 {
+                totalHeight += rowHeight + spacing
+                maxRowWidth = max(maxRowWidth, rowWidth - spacing)
+                rowWidth = 0; rowHeight = 0
+            }
+            rowWidth += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        totalHeight += rowHeight
+        maxRowWidth = max(maxRowWidth, rowWidth - spacing)
+        return CGSize(width: min(maxWidth, maxRowWidth), height: totalHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX, y = bounds.minY, rowHeight: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX, x > bounds.minX {
+                x = bounds.minX; y += rowHeight + spacing; rowHeight = 0
+            }
+            sub.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the Step 2 command. Expected: PASS (5 tests).
+
+- [ ] **Step 5: Build to verify the view compiles**
+
+Run: `xcodebuild build -scheme TheRecruitingCompass -destination 'platform=iOS Simulator,name=iPhone 17' -quiet` — expect exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Components/CoreCoursesEditor.swift TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences/CoreCoursesLogicTests.swift
+git commit -m "feat(profile): add CoreCoursesEditor chip component"
+```
+
+---
+
+### Task A3: Move High School + add Core Courses into Academics tab
+
+**Files:**
+- Modify: `TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AcademicsSocialTab.swift`
+
+**Interfaces:**
+- Consumes: `CoreCoursesEditor` (A2), `PlayerDetails.coreCourses` (A1), existing `textRow(_:placeholder:keyPath:keyboardType:)` helper in this file.
+- Produces: Academics tab content order — High School → Academics → Core Courses. Removes Social Media + Privacy cards (they move to Basics in A4).
+
+- [ ] **Step 1: Edit the `body`**
+
+Replace the `body`'s `VStack` contents so the cards are, in order: High School, Academics, Core Courses. Remove the `Social Media` and `Privacy` `cardSection` blocks entirely.
+
+```swift
+            VStack(spacing: 16) {
+                cardSection(String(localized: "High School")) {
+                    VStack(spacing: 0) {
+                        textRow(String(localized: "High School"), keyPath: \.highSchool)
+                        divider
+                        textRow(String(localized: "City"), keyPath: \.schoolCity)
+                        divider
+                        textRow(String(localized: "State"), keyPath: \.schoolState)
+                    }
+                }
+
+                cardSection(String(localized: "Academics")) {
+                    VStack(spacing: 0) {
+                        numericRow(String(localized: "GPA"), keyPath: \.gpa)
+                        divider
+                        intRow(String(localized: "SAT Score"), keyPath: \.satScore)
+                        divider
+                        intRow(String(localized: "ACT Score"), keyPath: \.actScore)
+                    }
+                }
+
+                cardSection(String(localized: "Core Courses")) {
+                    CoreCoursesEditor(
+                        courses: Binding(
+                            get: { viewModel.details.coreCourses ?? [] },
+                            set: {
+                                viewModel.details.coreCourses = $0.isEmpty ? nil : $0
+                                viewModel.markChanged()
+                            }
+                        ),
+                        isDisabled: viewModel.isReadOnly
+                    )
+                }
+            }
+```
+
+Note: `textRow` here forces `.textInputAutocapitalization(.never)` + `.autocorrectionDisabled()` (it was built for handles). For High School/City/State that is acceptable but not ideal; if a State field should uppercase, leave as-is for now — parity with the simple text entry is fine and matches the moved-from behavior. (The Basics version used `.characters` for State; capturing that nuance is out of scope — City/State here use the shared handle-style row.)
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild build -scheme TheRecruitingCompass -destination 'platform=iOS Simulator,name=iPhone 17' -quiet` — expect exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/AcademicsSocialTab.swift
+git commit -m "feat(profile): Academics tab now holds High School + Core Courses"
+```
+
+---
+
+### Task A4: Move Contact + Privacy + Social into Basics tab
+
+**Files:**
+- Modify: `TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift`
+
+**Interfaces:**
+- Consumes: existing `viewModel.details` bindings, `markChanged()`, `isReadOnly`, and the `cardSection`/`divider` helpers already in BasicsTab.
+- Produces: Basics content order — Profile Photo → Basic Information (grad year, primary sport only) → Contact → Social → College Preferences.
+
+- [ ] **Step 1: Remove High School/City/State from `basicInfoCard`**
+
+Current `basicInfoCard` has gradYear, primarySport, High School, City, State rows. Reduce to:
+
+```swift
+    private var basicInfoCard: some View {
+        VStack(spacing: 0) {
+            gradYearRow
+            divider
+            primarySportRow
+        }
+    }
+```
+
+- [ ] **Step 2: Add Contact + Social cards to `body`**
+
+Insert between `Basic Information` and `College Preferences` sections:
+
+```swift
+                cardSection(String(localized: "Basic Information")) {
+                    basicInfoCard
+                }
+
+                cardSection(String(localized: "Contact")) {
+                    contactCard
+                }
+
+                cardSection(String(localized: "Social")) {
+                    socialCard
+                }
+
+                cardSection(String(localized: "College Preferences")) {
+                    collegePrefsCard
+                }
+```
+
+- [ ] **Step 3: Add the `contactCard`, `socialCard`, and shared helpers**
+
+```swift
+    // MARK: - Contact Card
+
+    @ViewBuilder
+    private var contactCard: some View {
+        VStack(spacing: 0) {
+            handleRow(String(localized: "Phone"), placeholder: String(localized: "Phone"),
+                      keyPath: \.phone, keyboardType: .phonePad)
+            divider
+            handleRow(String(localized: "Email"), placeholder: String(localized: "Email"),
+                      keyPath: \.email, keyboardType: .emailAddress)
+            divider
+            toggleRow(String(localized: "Share phone with coaches"), keyPath: \.allowSharePhone)
+            divider
+            toggleRow(String(localized: "Share email with coaches"), keyPath: \.allowShareEmail)
+        }
+    }
+
+    // MARK: - Social Card
+
+    @ViewBuilder
+    private var socialCard: some View {
+        VStack(spacing: 0) {
+            handleRow(String(localized: "Twitter"), placeholder: String(localized: "@username"), keyPath: \.twitterHandle)
+            divider
+            handleRow(String(localized: "Instagram"), placeholder: String(localized: "@username"), keyPath: \.instagramHandle)
+            divider
+            handleRow(String(localized: "TikTok"), placeholder: String(localized: "@username"), keyPath: \.tiktokHandle)
+            divider
+            handleRow(String(localized: "Facebook URL"), placeholder: String(localized: "https://..."), keyPath: \.facebookUrl, keyboardType: .URL)
+        }
+    }
+
+    private func handleRow(
+        _ label: String,
+        placeholder: String = "",
+        keyPath: WritableKeyPath<PlayerDetails, String?>,
+        keyboardType: UIKeyboardType = .default
+    ) -> some View {
+        HStack {
+            Text(label).font(.body)
+            Spacer()
+            TextField(placeholder.isEmpty ? label : placeholder, text: Binding(
+                get: { viewModel.details[keyPath: keyPath] ?? "" },
+                set: {
+                    viewModel.details[keyPath: keyPath] = $0.isEmpty ? nil : $0
+                    viewModel.markChanged()
+                }
+            ))
+            .multilineTextAlignment(.trailing)
+            .foregroundStyle(.secondary)
+            .keyboardType(keyboardType)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .disabled(viewModel.isReadOnly)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+    }
+
+    private func toggleRow(_ label: String, keyPath: WritableKeyPath<PlayerDetails, Bool?>) -> some View {
+        Toggle(label, isOn: Binding(
+            get: { viewModel.details[keyPath: keyPath] ?? false },
+            set: {
+                viewModel.details[keyPath: keyPath] = $0
+                viewModel.markChanged()
+            }
+        ))
+        .disabled(viewModel.isReadOnly)
+        .padding(.horizontal)
+        .padding(.vertical, 12)
+    }
+```
+
+- [ ] **Step 4: Build**
+
+Run: `xcodebuild build -scheme TheRecruitingCompass -destination 'platform=iOS Simulator,name=iPhone 17' -quiet` — expect exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add TheRecruitingCompass/TheRecruitingCompass/Features/Preferences/Views/Tabs/BasicsTab.swift
+git commit -m "feat(profile): Basics tab now holds Contact, Privacy, and Social"
+```
+
+---
+
+### Task A5: iOS full-suite regression + tab-title sanity
+
+**Files:**
+- Modify (only if a test references the moved fields' old tab): existing tests under `TheRecruitingCompassTests/Features/Preferences/`.
+
+- [ ] **Step 1: Grep for tests asserting old placement**
+
+Run: `grep -rn "Social Media\|Privacy\|High School\|schoolCity\|schoolState" TheRecruitingCompass/TheRecruitingCompassTests/Features/Preferences`
+For any test asserting a field appears on a specific tab, update it to the new tab. If a test only checks the view builds/loads, no change.
+
+- [ ] **Step 2: Run the Preferences test folder**
+
+Run: `xcodebuild test -scheme TheRecruitingCompass -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:TheRecruitingCompassTests/PlayerDetailsCodableTests -only-testing:TheRecruitingCompassTests/CoreCoursesLogicTests`
+Expected: PASS. Then run any updated view tests by class name. Trust exit code.
+
+- [ ] **Step 3: Commit any test updates**
+
+```bash
+git add -A
+git commit -m "test(profile): align player-profile tests with new field homes"
+```
+
+---
+
+## Phase B — Web
+
+### Task B1: Rename the Academics tab label
+
+**Files:**
+- Modify: `pages/settings/player-details.vue:338`
+- Test: `tests/unit/` (add/extend a tab-config test if one exists; otherwise assert in the Academics component test in B4)
+
+**Interfaces:**
+- Produces: tab `{ id: "academics", name: "Academics" }`.
+
+- [ ] **Step 1: Change the label**
+
+At line 338, change `name: "Academics & Social"` to `name: "Academics"`. Leave `id: "academics"` unchanged.
+
+- [ ] **Step 2: Grep for hardcoded references**
+
+Run: `grep -rn "Academics & Social\|Academics &amp; Social" .` (excluding node_modules). Update any snapshot/test copy.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pages/settings/player-details.vue
+git commit -m "feat(profile): rename Academics & Social tab to Academics"
+```
+
+---
+
+### Task B2: Move High School inputs Basics → Academics
+
+**Files:**
+- Modify: `components/Settings/PlayerDetailsBasicsTab.vue` (remove School Info block, lines ~67–122: High School Name / School City / School State, incl. `SharedHighSchoolSearchInput`)
+- Modify: `components/Settings/PlayerDetailsAcademicsTab.vue` (add the block at top)
+- Modify: `pages/settings/player-details.vue` (thread any props the block needs to the Academics tag; remove now-unused ones from Basics tag if they become unused)
+
+**Interfaces:**
+- Consumes: the block's inline `HighSchoolSelection` handler (currently in BasicsTab around line 84) mutates `form.high_school` / `form.school_city` / `form.school_state`; carry it verbatim into AcademicsTab. `SharedHighSchoolSearchInput` is a global/auto-imported component — no new import needed.
+- Produces: High School section as the first card in AcademicsTab.
+
+- [ ] **Step 1: Cut the School Info block from BasicsTab**
+
+Remove the `<!-- School Info -->` block (High School Name label + `SharedHighSchoolSearchInput`, School City, School State) from `PlayerDetailsBasicsTab.vue`.
+
+- [ ] **Step 2: Paste it as the first section in AcademicsTab**
+
+Insert the block above the existing Academic Info section in `PlayerDetailsAcademicsTab.vue`, wrapped in the same card container style the other sections use (copy the wrapper classes from the adjacent Core Courses/Academic Info card). Keep the inline `@select` handler that sets `form.high_school`, `form.school_city`, `form.school_state`.
+
+- [ ] **Step 3: Update tests to expect the failing state first**
+
+In `tests/unit/` add/extend a component test:
+
+```ts
+// PlayerDetailsAcademicsTab renders High School inputs
+expect(wrapper.find('[data-test="hs-name"]').exists()).toBe(true);
+// PlayerDetailsBasicsTab no longer renders High School
+expect(basicsWrapper.find('[data-test="hs-name"]').exists()).toBe(false);
+```
+
+Add matching `data-test` attributes to the moved inputs.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run tests/unit/components/Settings` (adjust path to where the component tests live). Expected: PASS after the move.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/Settings/PlayerDetailsBasicsTab.vue components/Settings/PlayerDetailsAcademicsTab.vue pages/settings/player-details.vue tests/
+git commit -m "feat(profile): move High School inputs from Basics to Academics"
+```
+
+---
+
+### Task B3: Consolidate Contact + Privacy into Basics; remove the Academics duplicate
+
+**Files:**
+- Modify: `components/Settings/PlayerDetailsBasicsTab.vue` (keep existing Recruiting Email/Phone block ~124–163; add the two privacy toggles beneath it)
+- Modify: `components/Settings/PlayerDetailsAcademicsTab.vue` (remove the entire "Contact & Privacy" block — the duplicate `form.phone`/`form.email` inputs and both toggles, ~lines 153–225)
+
+**Interfaces:**
+- Consumes: `form.phone`, `form.email`, `form.allow_share_phone`, `form.allow_share_email`, `triggerSave`. All already available in BasicsTab.
+- Produces: exactly one editing home for phone/email (Basics). Basics email/phone block relabeled "Contact"; toggles for share-phone/share-email added under it.
+
+- [ ] **Step 1: Write the failing assertion**
+
+Extend the component tests:
+
+```ts
+// Basics has the single contact home incl. privacy toggles
+expect(basics.find('[data-test="share-phone"]').exists()).toBe(true);
+expect(basics.find('[data-test="share-email"]').exists()).toBe(true);
+// Academics no longer edits phone/email
+expect(academics.find('[data-test="contact-phone"]').exists()).toBe(false);
+```
+
+- [ ] **Step 2: Remove the Academics Contact & Privacy block**
+
+Delete the "Contact & Privacy" section (`h2` "Contact & Privacy" through the two toggle rows) from `PlayerDetailsAcademicsTab.vue`.
+
+- [ ] **Step 3: Add the toggles under Basics' contact block**
+
+In `PlayerDetailsBasicsTab.vue`, under the Recruiting Phone input, add the two toggle rows (copy the toggle markup that was in AcademicsTab, binding `form.allow_share_phone` / `form.allow_share_email`, calling `triggerSave` on change). Add `data-test="share-phone"` / `data-test="share-email"`. Optionally relabel the block comment to "Contact".
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run tests/unit/components/Settings`. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/Settings/PlayerDetailsBasicsTab.vue components/Settings/PlayerDetailsAcademicsTab.vue tests/
+git commit -m "feat(profile): single contact home in Basics; drop Academics phone/email dup"
+```
+
+---
+
+### Task B4: Move Social Handles Academics → Basics + rethread props
+
+**Files:**
+- Modify: `components/Settings/PlayerDetailsAcademicsTab.vue` (remove Social Handles block ~115–150; remove now-unused `socialInputs` / `handleSocialBlur` from its `defineProps`)
+- Modify: `components/Settings/PlayerDetailsBasicsTab.vue` (add Social Handles block; add `socialInputs` + `handleSocialBlur` to its `defineProps`)
+- Modify: `pages/settings/player-details.vue` (move `:social-inputs` / `:handle-social-blur` bindings from the `<PlayerDetailsAcademicsTab>` tag to the `<PlayerDetailsBasicsTab>` tag)
+
+**Interfaces:**
+- Consumes from `player-details.vue`: `socialInputs`, `handleSocialBlur` (destructured from `usePlayerDetailsForm` at ~line 362–366).
+- Produces: Basics renders the four social handle inputs via `v-for="social in socialInputs"`.
+
+- [ ] **Step 1: Write the failing assertion**
+
+```ts
+// Basics renders social handles; Academics does not
+expect(basics.find('[data-test="social-twitter_handle"]').exists()).toBe(true);
+expect(academics.find('[data-test="social-twitter_handle"]').exists()).toBe(false);
+```
+
+Add `:data-test="`social-${social.key}`"` to the social input wrapper when moving it.
+
+- [ ] **Step 2: Cut the Social Handles block from AcademicsTab; paste into BasicsTab**
+
+Move the `<!-- Social Media -->` section (h2 "Social Handles" + the `v-for` inputs) into `PlayerDetailsBasicsTab.vue` (place after the Contact section, before College Preferences to match iOS order).
+
+- [ ] **Step 3: Rethread props**
+
+- In `PlayerDetailsBasicsTab.vue` `defineProps`, add:
+  ```ts
+  socialInputs: { key: keyof PlayerDetails; label: string; placeholder: string; prefix?: string }[];
+  handleSocialBlur: (key: string, value: string) => void;
+  ```
+  (Match the exact shape currently declared in AcademicsTab's `defineProps`.)
+- In `PlayerDetailsAcademicsTab.vue` `defineProps`, remove `socialInputs` and `handleSocialBlur`.
+- In `pages/settings/player-details.vue`, move `:social-inputs="socialInputs"` and `:handle-social-blur="handleSocialBlur"` from the `<PlayerDetailsAcademicsTab .../>` tag to the `<PlayerDetailsBasicsTab .../>` tag.
+
+- [ ] **Step 4: Run the tests + typecheck**
+
+Run: `npx vitest run tests/unit/components/Settings` then `npx nuxi typecheck` (or the repo's typecheck script). Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/Settings/PlayerDetailsBasicsTab.vue components/Settings/PlayerDetailsAcademicsTab.vue pages/settings/player-details.vue tests/
+git commit -m "feat(profile): move Social Handles from Academics to Basics"
+```
+
+---
+
+### Task B5: Web regression + manual parity check
+
+- [ ] **Step 1: Full unit run**
+
+Run: `npx vitest run` (or repo test script). Expected: PASS. Fix any snapshot referencing old placement.
+
+- [ ] **Step 2: Manual smoke (dev server)**
+
+Run the app, open Settings → Player Details. Verify: Basics shows grad/sport, Contact (phone/email + 2 toggles), Social (4), College Preferences; Academics shows High School (name/city/state), GPA/SAT/ACT, Core Courses; phone/email editable in exactly one place; a value typed in Basics persists (triggerSave) and reloads.
+
+- [ ] **Step 3: Commit any snapshot fixes**
+
+```bash
+git add -A
+git commit -m "test(profile): update web snapshots for tab reorg"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- iOS missing `core_courses` → A1, A2, A3. ✓
+- iOS missing phone/email inputs → A4 (Contact card). ✓
+- Contact+Privacy → Basics → A4 (iOS), B3 (web). ✓
+- Social → Basics → A4 (iOS), B4 (web). ✓
+- High School → Academics → A3 (iOS), B2 (web). ✓
+- Web dup phone/email collapse → B3. ✓
+- Rename web tab → B1. ✓
+- Campus/cost stay, Athletics/History/IDs untouched → not modified by any task. ✓
+- No migration → no DB task. ✓
+
+**Placeholder scan:** No TBD/TODO. Core-courses rules are concrete (20/60/trim/dedupe). Web move tasks reference exact files, line ranges, prop names, and `data-test` hooks rather than reproducing entire Vue DOM blocks (the blocks are moved verbatim, not rewritten).
+
+**Type consistency:** `coreCourses: [String]?` (A1) used by `CoreCoursesEditor(courses: Binding<[String]>...)` (A2) via `?? []` bridge (A3). `normalizedToAdd(_:existing:)` signature consistent A2↔tests. Web `socialInputs`/`handleSocialBlur` prop shapes moved intact B4.
+
+**Open risk flagged in A3:** the shared iOS `textRow` forces `.never` autocapitalization; State field loses the `.characters` uppercase the Basics version had. Documented as an accepted minor divergence, not a silent change.

--- a/docs/superpowers/specs/2026-08-10-player-profile-tab-reorg-design.md
+++ b/docs/superpowers/specs/2026-08-10-player-profile-tab-reorg-design.md
@@ -1,0 +1,101 @@
+# Player Profile — Tab Reorganization (iOS + Web)
+
+**Date:** 2026-08-10
+**Status:** Approved (brainstorming) — pending spec review
+**Scope:** Player Profile / Player Details settings. Both `recruiting-compass-ios` and `recruiting-compass-web`.
+
+## Problem
+
+Field placement across the Player Profile tabs is inconsistent and, on web, duplicated:
+
+- **iOS is missing fields web has:** `core_courses`, and contact `phone` / `email` **inputs** (iOS only exposes the share-with-coaches privacy toggles, never the phone/email fields themselves).
+- **Contact/privacy lives under Academics**, which is the wrong mental bucket — it is identity/reachability, not academic record.
+- **Web edits the same `phone`/`email` in two tabs** (Basics "Recruiting Email/Phone" + Academics "Contact & Privacy") — both bind `form.phone` / `form.email`. Same field, two homes.
+- School info (high school name/city/state) sits in Basics, but reads more naturally as academic context.
+
+## Goal
+
+Group fields by **purpose**, give each tab a clean identity, add the iOS-missing fields, and collapse the web contact duplication to a single home. **No data migration** — every field keeps its existing JSON key in the `user_preferences` player blob, so existing data and cross-platform reads are unaffected.
+
+## Target Information Architecture (both platforms)
+
+### Basics — "who they are + how to reach them"
+- Profile photo *(iOS only)*
+- Graduation year
+- Primary sport
+- **Contact** (block): `phone`, `email`, `allow_share_phone` toggle, `allow_share_email` toggle
+- **Social handles** (block): `twitter_handle`, `instagram_handle`, `tiktok_handle`, `facebook_url`
+- **College Preferences** (block): `campus_size_preference`, `cost_sensitivity` — *unchanged, stays here*
+
+### Athletics — UNCHANGED
+Physical (height/weight/bats/throws), Positions, Recruiting Database IDs (NCAA/Perfect Game/Prep — stay here), Video Links.
+
+### Academics — "school + record"
+- **High School** (block): `high_school` (name), `school_city`, `school_state` *(moved from Basics)*
+- GPA (`gpa`), SAT (`sat_score`), ACT (`act_score`)
+- **Core Courses** (block): `core_courses` — add/remove tag chips *(new on iOS)*
+
+### History — UNCHANGED
+Grade-level teams/coaches, travel team.
+
+## Field moves summary
+
+| Field(s) | From | To |
+|---|---|---|
+| `phone`, `email` inputs | Web Basics + Web Academics (dup) → **one home** | Basics (Contact block) |
+| `allow_share_phone`, `allow_share_email` | iOS Academics "Privacy" / Web Academics "Contact & Privacy" | Basics (Contact block, under phone/email) |
+| social handles (4) | iOS Academics / Web Academics | Basics (Social block) |
+| `high_school`, `school_city`, `school_state` | Basics | Academics (High School block) |
+| `core_courses` | — (missing on iOS) | Academics (new on iOS; already on web) |
+
+## Platform-specific work
+
+### iOS (`recruiting-compass-ios`)
+1. **Model** `Features/Preferences/Models/PlayerDetails.swift`: add `var coreCourses: [String]?` + CodingKey `core_courses = "core_courses"`. (`phone`, `email`, `allow_share_phone`, `allow_share_email`, `high_school`, `school_city`, `school_state`, socials already present.)
+2. **BasicsTab** `.../Views/Tabs/BasicsTab.swift`:
+   - Remove High School / City / State rows.
+   - Add **Contact** card: phone (`.phonePad`), email (`.emailAddress`, no autocap) text rows + the two share toggles.
+   - Add **Social handles** card: 4 text rows (X/Twitter, Instagram, TikTok, Facebook) — reuse the row style moved out of AcademicsSocialTab.
+   - Keep College Preferences card (added earlier this session).
+3. **AcademicsSocialTab** `.../Views/Tabs/AcademicsSocialTab.swift` → effectively "AcademicsTab":
+   - Remove Social Media + Privacy cards.
+   - Add **High School** card: name/city/state rows (moved from Basics).
+   - Add **Core Courses** card: tag-chip editor (see UI spec).
+   - Section order: High School → Academics (GPA/SAT/ACT) → Core Courses.
+4. **Core Courses chip UI** (new iOS component or inline in the tab): removable pills + text field + Add button. Constraints mirror web: max 20 courses, 60-char max per entry, trim, no duplicates, Return submits. Respect `viewModel.isReadOnly`. Writes via `viewModel.markChanged()`.
+
+### Web (`recruiting-compass-web`)
+1. **`pages/settings/player-details.vue:338`**: rename tab `name: "Academics & Social"` → `"Academics"`. Tab `id` stays `academics` (route/query stability).
+2. **`components/Settings/PlayerDetailsBasicsTab.vue`**:
+   - Remove High School Name / School City / School State inputs (move to Academics).
+   - Keep the existing email/phone inputs; add the two privacy toggles beneath them so Basics is the single Contact home.
+   - Add the Social Handles block (moved from Academics).
+3. **`components/Settings/PlayerDetailsAcademicsTab.vue`**:
+   - Remove Social Handles + Contact & Privacy blocks (the duplicate `form.phone`/`form.email` and the toggles).
+   - Add High School name/city/state inputs.
+   - Keep GPA/SAT/ACT + Core Courses. Order: High School → Academic Info → Core Courses.
+4. Update any tab-specific props (the tabs receive `campusSizeOptions`, etc. via props; ensure moved blocks get the option/handler props they need in their new host).
+
+## UI spec — Core Courses (both platforms, web is source of truth)
+- Header: "Core Courses", subtitle "AP, honors, or notable courses for your recruiting profile."
+- Chips: value text + remove (×) control (hidden/disabled when read-only).
+- Input row (shown when not read-only and count < 20): text field placeholder "e.g., AP Chemistry", maxlength 60; "Add" button disabled when input is blank; Return/Enter adds.
+- At 20 items: hide input, show "Maximum 20 courses added."
+- Stored as `core_courses: string[]` in the player blob.
+
+## Data / persistence
+- No schema or migration change. All keys already exist in `user_preferences.data` (category `player`): `phone`, `email`, `allow_share_phone`, `allow_share_email`, `core_courses`, `high_school`, `school_city`, `school_state`, `twitter_handle`, `instagram_handle`, `tiktok_handle`, `facebook_url`, `campus_size_preference`, `cost_sensitivity`.
+- Both platforms already Codable/serialize the whole blob; moving a field between tabs does not change what is written. iOS adds one new key (`core_courses`) it previously ignored on decode.
+
+## Testing
+- **iOS:** `PlayerDetails` round-trip test asserting `core_courses` encodes/decodes to `[String]`. Core-courses editor unit test: add / dedupe / trim / 20-cap / read-only. Keep/adjust any AcademicsSocialTab / BasicsTab tests to the new field homes. Build gate: `xcodebuild build` clean.
+- **Web:** component tests for BasicsTab (contact block incl. toggles, social block present; HS inputs absent) and AcademicsTab (HS inputs present; social + contact absent). Assert phone/email have exactly one editing home. Run existing `usePlayerDetailsForm` tests unchanged.
+
+## Non-goals / out of scope
+- No change to Athletics, History, or Public Profile (web) tabs.
+- No relocation of campus size / cost sensitivity (explicitly kept in Basics).
+- No DB migration, no new persisted fields beyond iOS adopting the existing `core_courses` key.
+- Recruiting DB IDs stay in Athletics.
+
+## Open questions
+None outstanding — the three placement decisions (contact+privacy → Basics; HS-only → Academics; campus/cost stay) are resolved.

--- a/planning/2026-08-10-ios-canonical-positions-parity.md
+++ b/planning/2026-08-10-ios-canonical-positions-parity.md
@@ -1,0 +1,83 @@
+# iOS handoff — canonical athlete positions (remove "Infielder", match web)
+
+**Date:** 2026-08-10
+**Direction:** web → iOS. Web is the source of truth (already shipped to prod).
+**Companion web work:** PR #354 (`utils/positions/canonical.ts`) + live DB backfill.
+
+---
+
+## HANDOFF PROMPT (paste into the iOS session)
+
+> Bring iOS athlete positions to parity with web (shipped in web PR #354). "Infielder"/"Outfielder" are not real positions and have been removed everywhere on web; onboarding and the family/edit pickers now offer ONE canonical, full-name, granular vocabulary per sport, and the shared DB has been backfilled so stored `primary_position` / `positions` are already canonical.
+>
+> Do this on iOS:
+> 1. Replace `OnboardingConstants.sportPositions` and `FamilyConstants.Positions.all` with the canonical sport-scoped map below (make `FamilyConstants` sport-scoped too — parent picks sport, then position).
+> 2. Add a sport-scoped `normalizePosition(sport:_ value:)` mirroring web (expand abbreviations, map coarse buckets `Infielder`/`Outfielder` → `Utility`, resolve `C`=Catcher vs Center and `P`=Pitcher vs Punter by sport, PRESERVE unknown values — never drop). Apply it when reading a stored `primary_position`/`positions` so any legacy value displays/selects cleanly.
+> 3. Verify `PlayerDetails.completenessScore` is unchanged (it already scores `primaryPosition` presence at 0.10 — no change needed).
+> 4. Confirm no picker still lists "Infielder"/"Outfielder"/"Guard"/"Lineman".
+>
+> Read the full spec at `planning/2026-08-10-ios-canonical-positions-parity.md`. Don't touch web files.
+
+---
+
+## Why
+
+Web unified six conflicting position vocabularies into one canonical source. iOS is now the last place offering the coarse "Infielder"/"Outfielder" (and `FamilyConstants` offers even coarser "Guard"/"Lineman"). Parent (iOS) and player (web) must see the same options, and stored values must round-trip identically. The shared DB is already canonical (web backfilled it), so iOS mainly needs to (a) offer the canonical vocabulary and (b) normalize any legacy value defensively on read.
+
+## Files to change
+
+| File | Current | Change |
+|---|---|---|
+| `Features/Onboarding/Utilities/OnboardingConstants.swift` | `sportPositions` sport-scoped, coarse (Infielder/Outfielder) | Replace with canonical map below |
+| `Features/Family/Utilities/FamilyConstants.swift` | `Positions.all` FLAT coarse list (Guard, Lineman, …) | Make sport-scoped; use canonical map |
+| `Features/Onboarding/ViewModels/OnboardingViewModel.swift` | reads `OnboardingConstants.sportPositions` | verify still compiles; picker shows canonical |
+| `Features/Family/ViewModels/ParentOnboardingWizardViewModel.swift` + family pickers (`FamilyManagement*`, `ParentFamilyCard`, `FamilyMemberCard`) | read `FamilyConstants.Positions.all` | switch to sport-scoped canonical lookup |
+| `Features/Preferences/Models/PlayerDetails.swift` | `completenessScore` scores `primaryPosition` presence (0.10) | NO change — parity already correct |
+
+New: a canonical positions helper (Swift equivalent of web `utils/positions/canonical.ts`) with `positions(for sport:)` and `normalize(sport:_ value:)`.
+
+## Canonical map (mirror web `SPORT_POSITIONS` exactly)
+
+```
+Baseball / Softball: Pitcher, Catcher, First Base, Second Base, Third Base,
+  Shortstop, Left Field, Center Field, Right Field, Designated Hitter, Utility
+Basketball: Point Guard, Shooting Guard, Small Forward, Power Forward, Center
+Football: Quarterback, Running Back, Wide Receiver, Tight End, Offensive Line,
+  Defensive Line, Linebacker, Defensive Back, Kicker, Punter
+Soccer: Goalkeeper, Defender, Midfielder, Forward
+Volleyball: Outside Hitter, Middle Blocker, Setter, Libero, Opposite Hitter, Defensive Specialist
+Track & Field: Sprinter, Distance Runner, Jumper, Thrower, Hurdler
+Swimming: Freestyle, Backstroke, Breaststroke, Butterfly, Individual Medley, Diver
+Cross Country: Runner
+Tennis: Singles, Doubles
+Golf: Golfer
+Lacrosse: Attackman, Midfielder, Defenseman, Goalie
+Field Hockey: Forward, Midfielder, Defender, Goalkeeper
+Ice Hockey: Forward, Defenseman, Goalie
+Wrestling: Wrestler
+Rowing: Rower
+Water Polo: Field Player, Goalkeeper
+```
+
+## Normalization rules (mirror web)
+
+- **Sport-scoped** — resolve by sport, never a flat map. Collisions: `C` = Catcher (baseball) vs Center (basketball); `P` = Pitcher (baseball) vs Punter (football).
+- Expand abbreviations: `P→Pitcher, C→Catcher, 1B→First Base, 2B→Second Base, 3B→Third Base, SS→Shortstop, LF→Left Field, CF→Center Field, RF→Right Field, DH→Designated Hitter, UTIL→Utility`; `PG→Point Guard, SG→Shooting Guard, SF→Small Forward, PF→Power Forward`; `QB→Quarterback, RB→Running Back, WR→Wide Receiver, TE→Tight End, OL→Offensive Line, DL→Defensive Line, LB→Linebacker, DB→Defensive Back, K→Kicker`; `GK→Goalkeeper, DEF→Defender, MID→Midfielder, FWD→Forward`.
+- Coarse buckets → `Utility`: `Infielder, Outfielder, Infield, Outfield, IF, OF`.
+- Already-canonical values pass through (case-insensitive). **Unknown values are PRESERVED, not dropped.**
+
+## Migration / data
+
+- No iOS-side DB migration needed — web already backfilled the shared project (`primary_position` + `positions[]` are canonical full names now).
+- One real-user note: `owen@andrikanich.com`'s `primary_position` was `Utility` (migrated from his old "Infielder"; his `positions[]` = Second/Third Base, Shortstop, Pitcher). If iOS shows a parent an empty/odd primary, that's why — they can pick a specific spot in the canonical picker.
+
+## Verify
+
+- No picker lists "Infielder"/"Outfielder"/"Guard"/"Lineman"/"Center" (basketball Center stays, but no generic "Center" in a flat list).
+- A baseball athlete with stored `Utility` shows "Utility" selected; `Shortstop` shows "Shortstop".
+- Completeness for a complete athlete = 85 (unchanged), matching web.
+- `swift build` / tests green.
+
+## Out of scope (web Phase 2, separate)
+
+- Web's dead `Screen2BasicInfo.vue` + object lookup, and the DB `positions` table vs `primary_position` string reconciliation — web-side, not iOS.


### PR DESCRIPTION
## Summary

Player Profile parity + reorganization (iOS). Multiple related changes to the Player Details tabs to bring iOS in line with the web app.

### Basics tab
- Add **campus size preference** + **cost sensitivity** (web-parity enums), and float the profile-photo layout (circle left, Choose/Delete right, Delete gains icon).
- Now the single home for **Contact** (phone/email + share-with-coaches toggles) and **Social handles** (X/Instagram/TikTok/Facebook), moved out of Academics.

### Athletics tab
- Section labels aligned with web: **Physical Profile** (now holds bats/throws), **Positions You Play**, **Recruiting Database IDs**.
- **Bats/Throws** highlight fix: replaced the too-faint system `.segmented` control with custom accent-filled selection (matches web).
- Added a **Video Links** section (pushes the existing editor).

### Academics tab
- Now holds **High School** (name/city/state, moved from Basics), GPA/SAT/ACT, and a new **Core Courses** chip editor (`core_courses`, web-parity: max 20, 60-char, dedupe/trim).
- Social + Privacy blocks removed (moved to Basics).

### Data
No DB/migration change — all fields keep their existing `user_preferences` player-blob JSON keys.

## Design / plan docs
- `docs/superpowers/specs/2026-08-10-player-profile-tab-reorg-design.md`
- `docs/superpowers/plans/2026-08-10-player-profile-tab-reorg.md`

## Test plan
- New unit tests: `PlayerDetailsCodableTests` (core_courses round-trip), `CoreCoursesLogicTests` (trim/blank/dedupe/cap/truncate) — green.
- Targeted suite: **74 passed / 1 failed**.

## ⚠️ Reviewer notes — read before merge
1. **This branch also contains `ab937d9` (`feat(positions): canonical sport-scoped athlete positions`)** authored by a concurrent session, not part of the tab-reorg work. It was committed to this shared branch upstream of the reorg commits. Included here because history builds on top of it.
2. **The one failing test — `PlayerDetailsViewModelTests.testNormalizePositions_TitleCasesAll` — comes from that `ab937d9` positions change, not the tab reorg.** `CanonicalPositions.normalize` returns raw values when `primarySport` is nil. Should be fixed by the positions work's owner before/at merge.

## Deferred cosmetics (non-blocking)
- CoreCoursesEditor "Maximum 20 courses added." renders even when read-only.
- One 147-char line (Facebook row) exceeds SwiftLint's 140 warn threshold.

## Not included
Web-side reorganization (Phase B) is deferred to a separate PR in `recruiting-compass-web`.

https://claude.ai/code/session_01AFmKmQxRdpfnKzLbsLRLjP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Core Courses editing with trimming, duplicate prevention, character limits, and a 20-course maximum.
  * Reorganized player profiles into clearer Basics, Academics, and Athletics sections.
  * Added contact, social, college preference, recruiting ID, video link, and core course fields.
  * Added improved photo controls and baseball/softball batting and throwing selections.

* **Improvements**
  * Standardized sport-specific position options and abbreviation handling across profiles.
  * Existing positions are automatically normalized while preserving unrecognized values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->