### PR TITLE
feat(dashboard): compact timeline summary card, move link to top-right

### DIFF
--- a/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Components/DashboardTimelineSummaryCard.swift
+++ b/TheRecruitingCompass/TheRecruitingCompass/Features/Dashboard/Components/DashboardTimelineSummaryCard.swift
@@ -25,8 +25,8 @@ struct DashboardTimelineSummaryCard: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      HStack(spacing: 12) {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 10) {
         Text(phase.displayLabel)
           .font(.caption.weight(.semibold))
           .foregroundStyle(badgeColor)
@@ -45,22 +45,25 @@ struct DashboardTimelineSummaryCard: View {
             .monospacedDigit()
         }
 
-        Spacer(minLength: 0)
+        Spacer(minLength: 8)
+
+        Button(action: onViewTimeline) {
+          HStack(spacing: 3) {
+            Text("Timeline")
+            Image(systemName: "arrow.right")
+              .accessibilityHidden(true)
+          }
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(Color.accentBlue)
+          .padding(.vertical, 4)
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("View timeline")
+        .fixedSize()
       }
 
       taskSection
-
-      Button(action: onViewTimeline) {
-        HStack(spacing: 4) {
-          Text("View timeline")
-          Image(systemName: "arrow.right")
-            .accessibilityHidden(true)
-        }
-        .font(.subheadline.weight(.medium))
-        .foregroundStyle(Color.accentBlue)
-      }
-      .buttonStyle(.plain)
-      .frame(maxWidth: .infinity, alignment: .trailing)
     }
     .padding()
     .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Why

On the dashboard the timeline summary card wasted vertical space: the **View timeline** link sat on its own trailing row while the top row (phase badge + status score) left its right half empty.

## Changes

- Fold the timeline link into the top row's empty right side (right-aligned after a Spacer); shorten visible text to **"Timeline →"** (accessibility label stays "View timeline").
- Drop the standalone third row → nets ~one row of height.
- `fixedSize()` prevents truncation; `contentShape` + vertical padding keep the tap target. Tighten spacing (12→8 vertical, 12→10 top-row gap).

Layout: `[Junior Year] [●20/100] ···· [Timeline →]` / task title + why.

## Test plan

- [x] `xcodebuild build` clean (EXIT=0)
- [ ] Eyeball on device — parent + player dashboards; verify link taps through to timeline and badge/score/link fit on one row at default Dynamic Type

https://claude.ai/code/session_01DfKUc46SNbxeivGzfasoSd